### PR TITLE
add alerts streamer from API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*.ipynb
 
 # pyenv
 .python-version

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -13,7 +13,8 @@ class Session:
     :param login: tastytrade username or email
     :param password: tastytrade password or a remember token obtained previously
     :param remember_me:
-        whether or not to generate a token which can be used to login without a password
+        whether or not to generate a token which can be used to login without a password;
+        appears to be bugged currently.
     :param two_factor_authentication:
         if two factor authentication is enabled, this is the code sent to the user's device
     :param is_certification: whether or not to use the certification API
@@ -38,7 +39,7 @@ class Session:
         validate_response(response)  # throws exception if not 200
 
         json = response.json()
-        #: The user dict returned by the API; contains email, username and ID
+        #: The user dict returned by the API; contains basic user information
         self.user: dict[str, str] = json['data']['user']
         #: The session token used to authenticate requests
         self.session_token: str = json['data']['session-token']

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -1,12 +1,14 @@
 import asyncio
 import json
 from asyncio import Lock, Queue, Task
-from typing import AsyncIterator, Optional
+from enum import Enum
+from typing import Any, AsyncIterator, Optional
 
 import requests
 import websockets
 
 from tastytrade import logger
+from tastytrade.account import Account
 from tastytrade.dxfeed import Channel
 from tastytrade.dxfeed.event import Event, EventType
 from tastytrade.dxfeed.greeks import Greeks
@@ -18,14 +20,154 @@ from tastytrade.dxfeed.trade import Trade
 from tastytrade.session import Session
 from tastytrade.utils import TastytradeError, validate_response
 
+CERT_STREAMER_URL = 'wss://streamer.cert.tastyworks.com'
+STREAMER_URL = 'wss://streamer.tastyworks.com'
+
+
+class SubscriptionType(str, Enum):
+    """
+    This is an :class:`~enum.Enum` that contains the subscription types for the alert streamer.
+    """
+    ACCOUNT = 'connect'  # 'account-subscribe' may be deprecated in the future, but is equivalent
+    HEARTBEAT = 'heartbeat'
+    PUBLIC_WATCHLISTS = 'public-watchlists-subscribe'
+    QUOTE_ALERTS = 'quote-alerts-subscribe'
+    USER_MESSAGE = 'user-message-subscribe'
+
+
+class AlertStreamer:
+    """
+    Used to subscribe to account-level updates (balances, orders, positions), public
+    watchlist updates, quote alerts, and user-level messages. It should always be
+    initialized using the :meth:`create` function, since the object cannot be fully
+    instantiated without using async.
+
+    Example usage::
+
+        session = Session('user', 'pass')
+        streamer = await AlertStreamer.create(session)
+        
+        await streamer.public_watchlists_subscribe()
+        await streamer.quote_alerts_subscribe()
+        await streamer.user_message_subscribe(session)
+
+        async for data in streamer.listen():
+            print(data)
+
+    """
+    def __init__(self, session: Session):
+        #: The active session used to initiate the streamer or make requests
+        self.token = session.session_token
+        self.base_url = CERT_STREAMER_URL if session.is_certification else STREAMER_URL
+
+        self._done = False
+        self._queue = Queue()
+        self._websocket = None
+
+    @classmethod
+    async def create(cls, session: Session) -> 'AlertStreamer':
+        """
+        Factory method for the :class:`DataStreamer` object. Simply calls the
+        constructor and performs the asynchronous setup tasks. This should be used
+        instead of the constructor.
+
+        :param session: active user session to use
+        """
+        self = cls(session)
+        self._connect_task = asyncio.create_task(self._connect())
+        while not self._websocket:
+            await asyncio.sleep(0.1)
+        self._heartbeat_task = asyncio.create_task(self._heartbeat())
+
+        return self
+
+    async def _connect(self) -> None:
+        """
+        Connect to the websocket server using the URL and authorization token provided
+        during initialization.
+        """
+        headers = {'Authorization': f'Bearer {self.token}'}
+        async with websockets.connect(self.base_url, extra_headers=headers) as websocket:  # type: ignore
+            self._websocket = websocket
+
+            while not self._done:
+                raw_message = await self._websocket.recv()
+                logger.debug('raw message: %s', raw_message)
+                await self._queue.put(json.loads(raw_message))
+                
+    async def listen(self) -> AsyncIterator[Any]:
+        """
+        Iterate over non-heartbeat messages received from the streamer.
+        """
+        while True:
+            data = await self._queue.get()
+            if data['action'] != SubscriptionType.HEARTBEAT:
+                yield data
+
+    async def account_subscribe(self, accounts: list[Account]) -> None:
+        """
+        Subscribes to account-level updates (balances, orders, positions).
+        
+        :param accounts: list of :class:`Account`s to subscribe to updates for
+        """
+        await self._subscribe(SubscriptionType.ACCOUNT, [acc.account_number for acc in accounts])
+
+    async def public_watchlists_subscribe(self) -> None:
+        """
+        Subscribes to public watchlist updates.
+        """
+        await self._subscribe(SubscriptionType.PUBLIC_WATCHLISTS)
+
+    async def quote_alerts_subscribe(self) -> None:
+        """
+        Subscribes to quote alerts (which are configured at a user level).
+        """
+        await self._subscribe(SubscriptionType.QUOTE_ALERTS)
+
+    async def user_message_subscribe(self, session: Session) -> None:
+        """
+        Subscribes to user-level messages.
+        """
+        external_id = session.user['external-id']
+        await self._subscribe(SubscriptionType.USER_MESSAGE, value=external_id)
+
+    async def close(self) -> None:
+        """
+        Closes the websocket connection and cancels the heartbeat task.
+        """
+        self._done = True
+        assert(self._connect_task is not None)  # something went horribly wrong
+        await asyncio.gather(self._connect_task, self._heartbeat_task)
+
+    async def _heartbeat(self) -> None:
+        """
+        Sends a heartbeat message every 10 seconds to keep the connection alive.
+        """
+        while not self._done:
+            await self._subscribe(SubscriptionType.HEARTBEAT, '')
+            # send the heartbeat every 10 seconds
+            await asyncio.sleep(10)
+
+    async def _subscribe(self, subscription: SubscriptionType, value: Optional[str] | list[str] = '') -> None:
+        """
+        Subscribes to one of the :class:`SubscriptionType`s. Depending on the kind of
+        subscription, the value parameter may be required.
+        """
+        message = {
+            'auth-token': self.token,
+            'action': subscription
+        }
+        if value:
+            message['value'] = value
+        logger.debug('sending alert subscription: %s', message)
+        await self._websocket.send(json.dumps(message))
+
 
 class DataStreamer:
     """
     A :class:`DataStreamer` object is used to fetch quotes or greeks for a given symbol
     or list of symbols. It should always be initialized using the :meth:`create` function,
     since the object cannot be fully instantiated without using async.
-
-    :param session: active user session to use
 
     Example usage::
 
@@ -67,7 +209,7 @@ class DataStreamer:
         self = cls(session)
         self._connect_task = asyncio.create_task(self._connect())
         while not self.client_id:
-            await asyncio.sleep(0.25)
+            await asyncio.sleep(0.1)
 
         return self
 
@@ -84,11 +226,11 @@ class DataStreamer:
         headers = {'Authorization': 'Bearer ' + self._auth_token}
 
         async with websockets.connect(self._wss_url, extra_headers=headers) as websocket:  # type: ignore
-            self.websocket = websocket
+            self._websocket = websocket
             await self._handshake()
 
             while not self.client_id:
-                raw_message = await self.websocket.recv()
+                raw_message = await self._websocket.recv()
                 message = json.loads(raw_message)[0]
 
                 logger.debug('received: %s', message)
@@ -100,7 +242,7 @@ class DataStreamer:
                         raise TastytradeError('Handshake failed')
 
             while not self._done:
-                raw_message = await self.websocket.recv()
+                raw_message = await self._websocket.recv()
                 message = json.loads(raw_message)[0]
 
                 if message['channel'] == Channel.DATA:
@@ -140,17 +282,18 @@ class DataStreamer:
                 'interval': 0
             }
         }
-        await self.websocket.send(json.dumps([message]))
+        await self._websocket.send(json.dumps([message]))
 
-    async def listen(self) -> AsyncIterator[list[Event]]:
+    async def listen(self) -> AsyncIterator[Event]:
         """
         Using the existing subscriptions, pulls greeks or quotes and yield returns them.
         Never exits unless there's an error or the channel is closed.
         """
         while True:
-            message = await self._queue.get()
-            logger.debug('popped message: %s', message)
-            yield _map_message(message)
+            raw_data = await self._queue.get()
+            messages = _map_message(raw_data)
+            for message in messages:
+                yield message
 
     async def close(self) -> None:
         """
@@ -173,30 +316,32 @@ class DataStreamer:
                 'connectionType': 'websocket'
             }
             logger.debug('sending heartbeat: %s', message)
-            await self.websocket.send(json.dumps([message]))
+            await self._websocket.send(json.dumps([message]))
             # send the heartbeat every 10 seconds
             await asyncio.sleep(10)
 
-    async def subscribe(self, key: EventType, dxfeeds: list[str]) -> None:
+    async def subscribe(self, key: EventType, dxfeeds: list[str], reset: bool = False) -> None:
         """
         Subscribes to quotes for given list of symbols. Used for recurring data feeds;
         if you just want to get a one-time quote, use :meth:`stream`.
 
         :param key: type of subscription to add
         :param dxfeeds: list of symbols to subscribe for
+        :param reset:
+            whether to reset the subscription list (remove all other subscriptions of all types)
         """
         id = await self._next_id()
         message = {
             'id': id,
             'channel': Channel.SUBSCRIPTION,
             'data': {
-                'reset': True,
+                'reset': reset,
                 'add': {key: dxfeeds}
             },
             'clientId': self.client_id
         }
         logger.debug('sending subscription: %s', message)
-        await self.websocket.send(json.dumps([message]))
+        await self._websocket.send(json.dumps([message]))
 
     async def unsubscribe(self, key: EventType, dxfeeds: list[str]) -> None:
         """
@@ -211,12 +356,12 @@ class DataStreamer:
             'channel': Channel.SUBSCRIPTION,
             'clientId': self.client_id,
             'data': {
-                'reset': True,
+                'reset': False,
                 'remove': {key: dxfeeds}
             }
         }
         logger.debug('sending unsubscription: %s', message)
-        await self.websocket.send(json.dumps([message]))
+        await self._websocket.send(json.dumps([message]))
 
     async def stream(self, key: EventType, dxfeeds: list[str]) -> list[Event]:
         """
@@ -224,6 +369,10 @@ class DataStreamer:
         the requested information once, then unsubscribes. If you want to maintain the
         subscription open, add a subscription with :meth:`subscribe` and listen with
         :meth:`listen`.
+
+        If you use this alongside :meth:`subscribe` and :meth:`listen`, you will get
+        some unexpected behavior. Most apps should use either this or :meth:`listen`
+        but not both.
 
         :param key: the type of subscription to stream, either greeks or quotes
         :param dxfeeds: list of symbols to subscribe to
@@ -233,7 +382,7 @@ class DataStreamer:
         await self.subscribe(key, dxfeeds)
         data = []
         async for item in self.listen():
-            data.extend(item)
+            data.append(item)
             if len(data) >= len(dxfeeds):
                 break
         await self.unsubscribe(key, dxfeeds)


### PR DESCRIPTION
Adds a websocket to allow you to subscribe to Tastytrade alerts:
- public watchlist updates
- quote alerts
- user-level messages, like "new account created" (not sure what the use of this is tbh)
- account-level updates (balances, orders, positions)
