### PR TITLE
Add TimeAndSale event

### DIFF
--- a/tastytrade/dxfeed/event.py
+++ b/tastytrade/dxfeed/event.py
@@ -15,8 +15,8 @@ class EventType(str, Enum):
     PROFILE = 'Profile'
     QUOTE = 'Quote'
     SUMMARY = 'Summary'
-    TIME_AND_SALE = 'TimeAndSale'
     THEO_PRICE = 'TheoPrice'
+    TIME_AND_SALE = 'TimeAndSale'
     TRADE = 'Trade'
 
 

--- a/tastytrade/dxfeed/event.py
+++ b/tastytrade/dxfeed/event.py
@@ -12,11 +12,12 @@ class EventType(str, Enum):
     """
     CANDLE = 'Candle'
     GREEKS = 'Greeks'
-    QUOTE = 'Quote'
-    TRADE = 'Trade'
     PROFILE = 'Profile'
+    QUOTE = 'Quote'
     SUMMARY = 'Summary'
+    TIME_AND_SALE = 'TimeAndSale'
     THEO_PRICE = 'TheoPrice'
+    TRADE = 'Trade'
 
 
 class Event(ABC):

--- a/tastytrade/dxfeed/timeandsale.py
+++ b/tastytrade/dxfeed/timeandsale.py
@@ -6,7 +6,7 @@ from .event import Event
 @dataclass
 class TimeAndSale(Event):
     """
-    A Quote event is a snapshot of the best bid and ask prices, and other fields that change with each quote.
+    TimeAndSale event represents a trade or other market event with a price, like market open/close price. TimeAndSale events are intended to provide information about trades in a continuous-time slice (unlike Trade events which are supposed to provide snapshots about the most recent trade). TimeAndSale events have a unique index that can be used for later correction/cancellation processing.
     """
     #: symbol of this event
     eventSymbol: str

--- a/tastytrade/dxfeed/timeandsale.py
+++ b/tastytrade/dxfeed/timeandsale.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+
+from .event import Event
+
+
+@dataclass
+class TimeAndSale(Event):
+    """
+    A Quote event is a snapshot of the best bid and ask prices, and other fields that change with each quote.
+    """
+    #: symbol of this event
+    eventSymbol: str
+    #: time of this event
+    eventTime: int
+    #: transactional event flags
+    eventFlags: int
+    #: unique per-symbol index of this time and sale event
+    index: int
+    #: timestamp of the original event
+    time: int
+    #: microseconds and nanoseconds part of time of the last bid or ask change
+    timeNanoPart: int
+    #: sequence of this quote
+    sequence: int
+    #: exchange code of this time and sale event
+    exchangeCode: str
+    #: price of this time and sale event
+    price: float
+    #: size of this time and sale event as integer number (rounded toward zero)
+    size: int
+    #: the current bid price on the market when this time and sale event had occured
+    bidPrice: float
+    #: the current ask price on the market when this time and sale event had occured
+    askPrice: float
+    #: sale conditions provided for this event by data feed
+    exchangeSaleConditions: str
+    #: transaction is concluded by exempting from compliance with some rule
+    tradeThroughExempt: str
+    #: initiator of the trade
+    aggressorSide: str
+    #: whether this transaction is a part of a multi-leg order
+    spreadLeg: bool
+    #: whether this transaction is completed during extended trading hours
+    extendedTradingHours: bool
+    #: normalized SaleCondition flag
+    validTick: bool
+    #: type of event - 0: new, 1: correction, 2: cancellation
+    type: str
+    #: Undocumented; always None
+    buyer: None
+    #: Undocumented; always None
+    seller: None

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -496,10 +496,10 @@ def _map_message(message) -> list[Event]:
         res = Quote.from_stream(data)
     elif msg_type == EventType.SUMMARY:
         res = Summary.from_stream(data)
-    elif msg_type == EventType.TIME_AND_SALE:
-        res = TimeAndSale.from_stream(data)
     elif msg_type == EventType.THEO_PRICE:
         res = TheoPrice.from_stream(data)
+    elif msg_type == EventType.TIME_AND_SALE:
+        res = TimeAndSale.from_stream(data)
     elif msg_type == EventType.TRADE:
         res = Trade.from_stream(data)
     else:

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -18,6 +18,7 @@ from tastytrade.dxfeed.profile import Profile
 from tastytrade.dxfeed.quote import Quote
 from tastytrade.dxfeed.summary import Summary
 from tastytrade.dxfeed.theoprice import TheoPrice
+from tastytrade.dxfeed.timeandsale import TimeAndSale
 from tastytrade.dxfeed.trade import Trade
 from tastytrade.session import Session
 from tastytrade.utils import TastytradeError, validate_response
@@ -495,6 +496,8 @@ def _map_message(message) -> list[Event]:
         res = Quote.from_stream(data)
     elif msg_type == EventType.SUMMARY:
         res = Summary.from_stream(data)
+    elif msg_type == EventType.TIME_AND_SALE:
+        res = TimeAndSale.from_stream(data)
     elif msg_type == EventType.THEO_PRICE:
         res = TheoPrice.from_stream(data)
     elif msg_type == EventType.TRADE:


### PR DESCRIPTION
This PR adds support for the TimeAndSale market event. DxFeed documentation on this event may be found in their [Javadocs](https://docs.dxfeed.com/dxfeed/api/com/dxfeed/event/market/TimeAndSale.html) and [knowledge base](https://kb.dxfeed.com/en/data-model/qd-model-of-market-events.html#timeandsale-60646)