### PR TITLE
Issue #53: get_balance_snapshots() fails with production account

### DIFF
--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -43,15 +43,6 @@ class AccountBalance(TastytradeJsonDataclass):
     day_trade_excess: Decimal
     pending_cash: Decimal
     pending_cash_effect: PriceEffect
-    long_cryptocurrency_value: Decimal
-    short_cryptocurrency_value: Decimal
-    cryptocurrency_margin_requirement: Decimal
-    unsettled_cryptocurrency_fiat_amount: Decimal
-    unsettled_cryptocurrency_fiat_effect: PriceEffect
-    closed_loop_available_balance: Decimal
-    equity_offering_margin_requirement: Decimal
-    long_bond_value: Decimal
-    bond_margin_requirement: Decimal
     snapshot_date: date
     reg_t_margin_requirement: Decimal
     futures_overnight_margin_requirement: Decimal
@@ -64,7 +55,15 @@ class AccountBalance(TastytradeJsonDataclass):
     effective_cryptocurrency_buying_power: Decimal
     updated_at: datetime
     time_of_day: Optional[str] = None
-
+    long_cryptocurrency_value: Optional[Decimal] = None
+    short_cryptocurrency_value: Optional[Decimal] = None
+    cryptocurrency_margin_requirement: Optional[Decimal] = None
+    unsettled_cryptocurrency_fiat_amount: Optional[Decimal] = None
+    unsettled_cryptocurrency_fiat_effect: Optional[PriceEffect] = None
+    closed_loop_available_balance: Optional[Decimal] = None
+    equity_offering_margin_requirement: Optional[Decimal] = None
+    long_bond_value: Optional[Decimal] = None
+    bond_margin_requirement: Optional[Decimal] = None
 
 class AccountBalanceSnapshot(TastytradeJsonDataclass):
     """

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -43,6 +43,15 @@ class AccountBalance(TastytradeJsonDataclass):
     day_trade_excess: Decimal
     pending_cash: Decimal
     pending_cash_effect: PriceEffect
+    long_cryptocurrency_value: Decimal
+    short_cryptocurrency_value: Decimal
+    cryptocurrency_margin_requirement: Decimal
+    unsettled_cryptocurrency_fiat_amount: Decimal
+    unsettled_cryptocurrency_fiat_effect: PriceEffect
+    closed_loop_available_balance: Decimal
+    equity_offering_margin_requirement: Decimal
+    long_bond_value: Decimal
+    bond_margin_requirement: Decimal
     snapshot_date: date
     reg_t_margin_requirement: Decimal
     futures_overnight_margin_requirement: Decimal
@@ -55,15 +64,6 @@ class AccountBalance(TastytradeJsonDataclass):
     effective_cryptocurrency_buying_power: Decimal
     updated_at: datetime
     time_of_day: Optional[str] = None
-    long_cryptocurrency_value: Optional[Decimal] = None
-    short_cryptocurrency_value: Optional[Decimal] = None
-    cryptocurrency_margin_requirement: Optional[Decimal] = None
-    unsettled_cryptocurrency_fiat_amount: Optional[Decimal] = None
-    unsettled_cryptocurrency_fiat_effect: Optional[PriceEffect] = None
-    closed_loop_available_balance: Optional[Decimal] = None
-    equity_offering_margin_requirement: Optional[Decimal] = None
-    long_bond_value: Optional[Decimal] = None
-    bond_margin_requirement: Optional[Decimal] = None
 
 class AccountBalanceSnapshot(TastytradeJsonDataclass):
     """
@@ -97,17 +97,19 @@ class AccountBalanceSnapshot(TastytradeJsonDataclass):
     day_trade_excess: Decimal
     pending_cash: Decimal
     pending_cash_effect: PriceEffect
-    long_cryptocurrency_value: Decimal
-    short_cryptocurrency_value: Decimal
-    cryptocurrency_margin_requirement: Decimal
-    unsettled_cryptocurrency_fiat_amount: Decimal
-    unsettled_cryptocurrency_fiat_effect: PriceEffect
-    closed_loop_available_balance: Decimal
-    equity_offering_margin_requirement: Decimal
-    long_bond_value: Decimal
-    bond_margin_requirement: Decimal
     snapshot_date: date
     time_of_day: Optional[str] = None
+    long_cryptocurrency_value: Optional[Decimal] = None
+    short_cryptocurrency_value: Optional[Decimal] = None
+    cryptocurrency_margin_requirement: Optional[Decimal] = None
+    unsettled_cryptocurrency_fiat_amount: Optional[Decimal] = None
+    unsettled_cryptocurrency_fiat_effect: Optional[PriceEffect] = None
+    closed_loop_available_balance: Optional[Decimal] = None
+    equity_offering_margin_requirement: Optional[Decimal] = None
+    long_bond_value: Optional[Decimal] = None
+    bond_margin_requirement: Optional[Decimal] = None
+
+
 
 
 class CurrentPosition(TastytradeJsonDataclass):

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -65,6 +65,7 @@ class AccountBalance(TastytradeJsonDataclass):
     updated_at: datetime
     time_of_day: Optional[str] = None
 
+
 class AccountBalanceSnapshot(TastytradeJsonDataclass):
     """
     Dataclass containing account balance for a moment in time (snapshot).
@@ -108,6 +109,7 @@ class AccountBalanceSnapshot(TastytradeJsonDataclass):
     equity_offering_margin_requirement: Optional[Decimal] = None
     long_bond_value: Optional[Decimal] = None
     bond_margin_requirement: Optional[Decimal] = None
+
 
 class CurrentPosition(TastytradeJsonDataclass):
     """

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -109,9 +109,6 @@ class AccountBalanceSnapshot(TastytradeJsonDataclass):
     long_bond_value: Optional[Decimal] = None
     bond_margin_requirement: Optional[Decimal] = None
 
-
-
-
 class CurrentPosition(TastytradeJsonDataclass):
     """
     Dataclass containing imformation about an individual position in a portfolio.


### PR DESCRIPTION
Certain AccountBalanceSnapshot weren't present in production accounts. As a result, calling get_balance_snapshots() in production would fail. Made the following fields optional per discussion with Graham in issue #53.

Changes tested locally and they work!