### PR TITLE
get_futures() method works again after removing some class variables

### DIFF
--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -616,11 +616,11 @@ class Future(TradeableTastytradeJsonDataclass):
     product_group: str
     exchange: str
     streamer_exchange_code: str
-    streamer_symbol: str = None
     back_month_first_calendar_symbol: bool
-    is_tradeable: bool = None
-    future_product: 'FutureProduct' = None
     instrument_type: InstrumentType = InstrumentType.FUTURE
+    streamer_symbol: Optional[str] = None
+    is_tradeable: Optional[bool] = None
+    future_product: Optional['FutureProduct'] = None
     contract_size: Optional[Decimal] = None
     main_fraction: Optional[Decimal] = None
     sub_fraction: Optional[Decimal] = None

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -616,10 +616,10 @@ class Future(TradeableTastytradeJsonDataclass):
     product_group: str
     exchange: str
     streamer_exchange_code: str
-    # streamer_symbol: str
+    streamer_symbol: str = None
     back_month_first_calendar_symbol: bool
-    # is_tradeable: bool
-    # future_product: 'FutureProduct'
+    is_tradeable: bool = None
+    future_product: 'FutureProduct' = None
     instrument_type: InstrumentType = InstrumentType.FUTURE
     contract_size: Optional[Decimal] = None
     main_fraction: Optional[Decimal] = None

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -616,10 +616,10 @@ class Future(TradeableTastytradeJsonDataclass):
     product_group: str
     exchange: str
     streamer_exchange_code: str
-    streamer_symbol: str
+    # streamer_symbol: str
     back_month_first_calendar_symbol: bool
-    is_tradeable: bool
-    future_product: 'FutureProduct'
+    # is_tradeable: bool
+    # future_product: 'FutureProduct'
     instrument_type: InstrumentType = InstrumentType.FUTURE
     contract_size: Optional[Decimal] = None
     main_fraction: Optional[Decimal] = None


### PR DESCRIPTION
Looks like following variables 
- streamer_symbol, 
- is_tradeable, 
- future_product

are not anymore provided by a 
GET /instruments/futures
request from tastytrade

This is the error I get when using the current released db33a07
```python
# results = symbol_search(s, 'ES')
fut = Future.get_futures(session=s)
print(fut[0])
```
```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[4], line 2
      1 # results = symbol_search(s, 'ES')
----> 2 fut = Future.get_futures(session=s)
      3 print(fut[0])

File ~\python\venvs\env311\Lib\site-packages\tastytrade\instruments.py:666, in Future.get_futures(cls, session, symbols, product_codes)
    662 validate_response(response)
    664 data = response.json()['data']['items']
--> 666 return [cls(**entry) for entry in data]

File ~\python\venvs\env311\Lib\site-packages\tastytrade\instruments.py:666, in <listcomp>(.0)
    662 validate_response(response)
    664 data = response.json()['data']['items']
--> 666 return [cls(**entry) for entry in data]

File ~\python\venvs\env311\Lib\site-packages\pydantic\main.py:150, in BaseModel.__init__(__pydantic_self__, **data)
    148 # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
    149 __tracebackhide__ = True
--> 150 __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)

ValidationError: 3 validation errors for Future
streamer-symbol
  Field required [type=missing, input_value={'symbol': '/6JU2', 'prod...2', 'symbol': '/6JZ2'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.1.2/v/missing
is-tradeable
  Field required [type=missing, input_value={'symbol': '/6JU2', 'prod...2', 'symbol': '/6JZ2'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.1.2/v/missing
future-product
  Field required [type=missing, input_value={'symbol': '/6JU2', 'prod...2', 'symbol': '/6JZ2'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.1.2/v/missing
```

after commenting out these 3 Future parameters the get_futures() function works again

```python
...
class Future(TradeableTastytradeJsonDataclass):
    """
    Dataclass that represents a Tastytrade future object. Contains information about
    the future and methods to fetch futures for symbol(s).
    """
...
    # streamer_symbol: str
    back_month_first_calendar_symbol: bool
    # is_tradeable: bool
    # future_product: 'FutureProduct'
...
```