### PR TITLE
Improvements for installation and login

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import find_packages, setup
 
 from tastytrade import VERSION
 
-
 f = open('README.rst', 'r')
 LONG_DESCRIPTION = f.read()
 f.close()

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,6 +4,11 @@ API_URL = 'https://api.tastyworks.com'
 CERT_URL = 'https://api.cert.tastyworks.com'
 VERSION = '5.7'
 
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+from .account import *
+from .instruments import *
+from .metrics import *
+from .search import *
+from .streamer import *

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any, Optional, Dict, List
 
 import requests
 
@@ -180,7 +180,7 @@ class MarginReportEntry(TastytradeJsonDataclass):
     maintenance_requirement_effect: PriceEffect
     buying_power: Decimal
     buying_power_effect: PriceEffect
-    groups: list[dict[str, Any]]
+    groups: List[Dict[str, Any]]
     price_increase_percent: Decimal
     price_decrease_percent: Decimal
 
@@ -207,7 +207,7 @@ class MarginReport(TastytradeJsonDataclass):
     reg_t_option_buying_power_effect: PriceEffect
     maintenance_excess: Decimal
     maintenance_excess_effect: PriceEffect
-    groups: list[MarginReportEntry]
+    groups: List[MarginReportEntry]
     last_state_timestamp: int
     initial_requirement: Optional[Decimal] = None
     initial_requirement_effect: Optional[PriceEffect] = None
@@ -355,7 +355,7 @@ class Transaction(TastytradeJsonDataclass):
     other_charge_description: Optional[str] = None
     reverses_id: Optional[int] = None
     cost_basis_reconciliation_date: Optional[date] = None
-    lots: Optional[list[Lot]] = None
+    lots: Optional[List[Lot]] = None
     agency_price: Optional[Decimal] = None
     principal_price: Optional[Decimal] = None
 
@@ -396,7 +396,7 @@ class Account(TastytradeJsonDataclass):
         cls,
         session: Session,
         include_closed=False
-    ) -> list['Account']:
+    ) -> List['Account']:
         """
         Gets all trading accounts from the Tastyworks platform. By default
         excludes closed accounts from the results.
@@ -480,7 +480,7 @@ class Account(TastytradeJsonDataclass):
         session: Session,
         snapshot_date: Optional[date] = None,
         time_of_day: Optional[str] = None
-    ) -> list[AccountBalanceSnapshot]:
+    ) -> List[AccountBalanceSnapshot]:
         """
         Returns a list of two balance snapshots. The first one is the
         specified date, or, if not provided, the oldest snapshot available.
@@ -516,15 +516,15 @@ class Account(TastytradeJsonDataclass):
     def get_positions(
         self,
         session: Session,
-        underlying_symbols: Optional[list[str]] = None,
+        underlying_symbols: Optional[List[str]] = None,
         symbol: Optional[str] = None,
         instrument_type: Optional[InstrumentType] = None,
         include_closed: bool = False,
         underlying_product_code: Optional[str] = None,
-        partition_keys: Optional[list[str]] = None,
+        partition_keys: Optional[List[str]] = None,
         net_positions: bool = False,
         include_marks: bool = False
-    ) -> list[CurrentPosition]:
+    ) -> List[CurrentPosition]:
         """
         Get the current positions of the account.
 
@@ -572,8 +572,8 @@ class Account(TastytradeJsonDataclass):
         page_offset: Optional[int] = None,
         sort: str = 'Desc',
         type: Optional[str] = None,
-        types: Optional[list[str]] = None,
-        sub_types: Optional[list[str]] = None,
+        types: Optional[List[str]] = None,
+        sub_types: Optional[List[str]] = None,
         start_date: Optional[date] = None,
         end_date: date = date.today(),
         instrument_type: Optional[InstrumentType] = None,
@@ -584,7 +584,7 @@ class Account(TastytradeJsonDataclass):
         futures_symbol: Optional[str] = None,
         start_at: Optional[datetime] = None,
         end_at: Optional[datetime] = None
-    ) -> list[Transaction]:
+    ) -> List[Transaction]:
         """
         Get transaction history of the account.
 
@@ -683,7 +683,7 @@ class Account(TastytradeJsonDataclass):
         self,
         session: Session,
         date: date = date.today()
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """
         Get the total fees for a given date.
 
@@ -707,7 +707,7 @@ class Account(TastytradeJsonDataclass):
         session: Session,
         time_back: Optional[str] = None,
         start_time: Optional[datetime] = None
-    ) -> list[NetLiqOhlc]:
+    ) -> List[NetLiqOhlc]:
         """
         Returns a list of account net liquidating value snapshots over the
         specified time period.
@@ -809,7 +809,7 @@ class Account(TastytradeJsonDataclass):
 
         return MarginReport(**data)
 
-    def get_live_orders(self, session: Session) -> list[PlacedOrder]:
+    def get_live_orders(self, session: Session) -> List[PlacedOrder]:
         """
         Get all live orders for the account.
 
@@ -866,13 +866,13 @@ class Account(TastytradeJsonDataclass):
         start_date: Optional[date] = None,
         end_date: Optional[date] = None,
         underlying_symbol: Optional[str] = None,
-        statuses: Optional[list[OrderStatus]] = None,
+        statuses: Optional[List[OrderStatus]] = None,
         futures_symbol: Optional[str] = None,
         underlying_instrument_type: Optional[InstrumentType] = None,
         sort: str = 'Desc',
         start_at: Optional[datetime] = None,
         end_at: Optional[datetime] = None
-    ) -> list[PlacedOrder]:
+    ) -> List[PlacedOrder]:
         """
         Get order history of the account.
 

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Optional, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
 

--- a/tastytrade/dxfeed/event.py
+++ b/tastytrade/dxfeed/event.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from enum import Enum
-
+from typing import List
 
 class EventType(str, Enum):
     """
@@ -22,7 +22,7 @@ class EventType(str, Enum):
 
 class Event(ABC):
     @classmethod
-    def from_stream(cls, data: list) -> list['Event']:
+    def from_stream(cls, data: list) -> List['Event']:
         """
         Makes a list of event objects from a list of raw trade data fetched by
         a :class:`~tastyworks.streamer.DataStreamer`.

--- a/tastytrade/dxfeed/event.py
+++ b/tastytrade/dxfeed/event.py
@@ -2,6 +2,7 @@ from abc import ABC
 from enum import Enum
 from typing import List
 
+
 class EventType(str, Enum):
     """
     This is an :class:`~enum.Enum` that contains the valid subscription types for

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Optional, List, Dict
+from typing import Any, Dict, List, Optional
 
 import requests
 

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, List, Dict
 
 import requests
 
@@ -105,7 +105,7 @@ class NestedOptionChainExpiration(TastytradeJsonDataclass):
     expiration_date: date
     days_to_expiration: int
     settlement_type: str
-    strikes: list[Strike]
+    strikes: List[Strike]
 
 
 class NestedFutureOptionChainExpiration(TastytradeJsonDataclass):
@@ -126,8 +126,8 @@ class NestedFutureOptionChainExpiration(TastytradeJsonDataclass):
     option_contract_symbol: str
     stops_trading_at: datetime
     settlement_type: str
-    strikes: list[Strike]
-    tick_sizes: list[TickSize]
+    strikes: List[Strike]
+    tick_sizes: List[TickSize]
 
 
 class NestedFutureOptionFuture(TastytradeJsonDataclass):
@@ -178,13 +178,13 @@ class Cryptocurrency(TradeableTastytradeJsonDataclass):
     is_closing_only: bool
     active: bool
     tick_size: Decimal
-    destination_venue_symbols: list[DestinationVenueSymbol]
+    destination_venue_symbols: List[DestinationVenueSymbol]
     streamer_symbol: Optional[str] = None
 
     @classmethod
     def get_cryptocurrencies(
-        cls, session: Session, symbols: list[str] = []
-    ) -> list['Cryptocurrency']:
+        cls, session: Session, symbols: List[str] = []
+    ) -> List['Cryptocurrency']:
         """
         Returns a list of cryptocurrency objects from the given symbols.
 
@@ -254,8 +254,8 @@ class Equity(TradeableTastytradeJsonDataclass):
     halted_at: Optional[datetime] = None
     stops_trading_at: Optional[datetime] = None
     is_fractional_quantity_eligible: Optional[bool] = None
-    tick_sizes: Optional[list[TickSize]] = None
-    option_tick_sizes: Optional[list[TickSize]] = None
+    tick_sizes: Optional[List[TickSize]] = None
+    option_tick_sizes: Optional[List[TickSize]] = None
 
     @classmethod
     def get_active_equities(
@@ -264,7 +264,7 @@ class Equity(TradeableTastytradeJsonDataclass):
         per_page: int = 1000,
         page_offset: Optional[int] = None,
         lendability: Optional[str] = None
-    ) -> list['Equity']:
+    ) -> List['Equity']:
         """
         Returns a list of actively traded :class:`Equity` objects.
 
@@ -284,7 +284,7 @@ class Equity(TradeableTastytradeJsonDataclass):
         if page_offset is None:
             page_offset = 0
             paginate = True
-        params: dict[str, Any] = {
+        params: Dict[str, Any] = {
             'per-page': per_page,
             'page-offset': page_offset,
             'lendability': lendability
@@ -317,11 +317,11 @@ class Equity(TradeableTastytradeJsonDataclass):
     def get_equities(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: Optional[List[str]] = None,
         lendability: Optional[str] = None,
         is_index: Optional[bool] = None,
         is_etf: Optional[bool] = None
-    ) -> list['Equity']:
+    ) -> List['Equity']:
         """
         Returns a list of :class:`Equity` objects from the given symbols.
 
@@ -335,7 +335,7 @@ class Equity(TradeableTastytradeJsonDataclass):
 
         :return: a list of :class:`Equity` objects.
         """
-        params: dict[str, Any] = {
+        params: Dict[str, Any] = {
             'symbol[]': symbols,
             'lendability': lendability,
             'is-index': is_index,
@@ -409,10 +409,10 @@ class Option(TradeableTastytradeJsonDataclass):
     def get_options(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: Optional[List[str]] = None,
         active: Optional[bool] = None,
         with_expired: Optional[bool] = None
-    ) -> list['Option']:
+    ) -> List['Option']:
         """
         Returns a list of :class:`Option` objects from the given symbols.
 
@@ -423,7 +423,7 @@ class Option(TradeableTastytradeJsonDataclass):
 
         :return: a list of :class:`Option` objects.
         """
-        params: dict[str, Any] = {
+        params: Dict[str, Any] = {
             'symbol[]': symbols,
             'active': active,
             'with-expired': with_expired
@@ -494,9 +494,9 @@ class NestedOptionChain(TastytradeJsonDataclass):
     root_symbol: str
     option_chain_type: str
     shares_per_contract: int
-    tick_sizes: list[TickSize]
-    deliverables: list[Deliverable]
-    expirations: list[NestedOptionChainExpiration]
+    tick_sizes: List[TickSize]
+    deliverables: List[Deliverable]
+    expirations: List[NestedOptionChainExpiration]
 
     @classmethod
     def get_chain(cls, session: Session, symbol: str) -> 'NestedOptionChain':
@@ -534,8 +534,8 @@ class FutureProduct(TastytradeJsonDataclass):
     description: str
     exchange: str
     product_type: str
-    listed_months: list[FutureMonthCode]
-    active_months: list[FutureMonthCode]
+    listed_months: List[FutureMonthCode]
+    active_months: List[FutureMonthCode]
     notional_multiplier: Decimal
     tick_size: Decimal
     display_factor: Decimal
@@ -557,13 +557,13 @@ class FutureProduct(TastytradeJsonDataclass):
     clearport_code: Optional[str] = None
     legacy_code: Optional[str] = None
     legacy_exchange_code: Optional[str] = None
-    option_products: Optional[list['FutureOptionProduct']] = None
+    option_products: Optional[List['FutureOptionProduct']] = None
 
     @classmethod
     def get_future_products(
         cls,
         session: Session
-    ) -> list['FutureProduct']:
+    ) -> List['FutureProduct']:
         """
         Returns a list of :class:`FutureProduct` objects available.
 
@@ -643,17 +643,17 @@ class Future(TradeableTastytradeJsonDataclass):
     roll_target_symbol: Optional[str] = None
     true_underlying_symbol: Optional[str] = None
     future_etf_equivalent: Optional[FutureEtfEquivalent] = None
-    tick_sizes: Optional[list[TickSize]] = None
-    option_tick_sizes: Optional[list[TickSize]] = None
-    spread_tick_sizes: Optional[list[TickSize]] = None
+    tick_sizes: Optional[List[TickSize]] = None
+    option_tick_sizes: Optional[List[TickSize]] = None
+    spread_tick_sizes: Optional[List[TickSize]] = None
 
     @classmethod
     def get_futures(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
-        product_codes: Optional[list[str]] = None
-    ) -> list['Future']:
+        symbols: Optional[List[str]] = None,
+        product_codes: Optional[List[str]] = None
+    ) -> List['Future']:
         """
         Returns a list of :class:`Future` objects from the given symbols
         or product codes.
@@ -667,7 +667,7 @@ class Future(TradeableTastytradeJsonDataclass):
 
         :return: a list of :class:`Future` objects.
         """
-        params: dict[str, Any] = {
+        params: Dict[str, Any] = {
             'symbol[]': symbols,
             'product-code[]': product_codes
         }
@@ -732,7 +732,7 @@ class FutureOptionProduct(TastytradeJsonDataclass):
     def get_future_option_products(
         cls,
         session: Session
-    ) -> list['FutureOptionProduct']:
+    ) -> List['FutureOptionProduct']:
         """
         Returns a list of :class:`FutureOptionProduct` objects available.
 
@@ -821,12 +821,12 @@ class FutureOption(TradeableTastytradeJsonDataclass):
     def get_future_options(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: Optional[List[str]] = None,
         root_symbol: Optional[str] = None,
         expiration_date: Optional[date] = None,
         option_type: Optional[OptionType] = None,
         strike_price: Optional[Decimal] = None
-    ) -> list['FutureOption']:
+    ) -> List['FutureOption']:
         """
         Returns a list of :class:`FutureOption` objects from the given symbols.
 
@@ -843,7 +843,7 @@ class FutureOption(TradeableTastytradeJsonDataclass):
 
         :return: a list of :class:`FutureOption` objects.
         """
-        params: dict[str, Any] = {
+        params: Dict[str, Any] = {
             'symbol[]': symbols,
             'option-root-symbol': root_symbol,
             'expiration-date': expiration_date,
@@ -895,7 +895,7 @@ class NestedFutureOptionSubchain(TastytradeJsonDataclass):
     underlying_symbol: str
     root_symbol: str
     exercise_style: str
-    expirations: list[NestedFutureOptionChainExpiration]
+    expirations: List[NestedFutureOptionChainExpiration]
 
 
 class NestedFutureOptionChain(TastytradeJsonDataclass):
@@ -907,8 +907,8 @@ class NestedFutureOptionChain(TastytradeJsonDataclass):
     want to create actual :class:`FutureOption` objects you'll need to make an
     extra API request or two.
     """
-    futures: list[NestedFutureOptionFuture]
-    option_chains: list[NestedFutureOptionSubchain]
+    futures: List[NestedFutureOptionFuture]
+    option_chains: List[NestedFutureOptionSubchain]
 
     @classmethod
     def get_chain(
@@ -953,8 +953,8 @@ class Warrant(TastytradeJsonDataclass):
     def get_warrants(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None
-    ) -> list['Warrant']:
+        symbols: Optional[List[str]] = None
+    ) -> List['Warrant']:
         """
         Returns a list of :class:`Warrant` objects from the given symbols.
 
@@ -1002,7 +1002,7 @@ FutureProduct.update_forward_refs()
 
 def get_quantity_decimal_precisions(
     session: Session
-) -> list[QuantityDecimalPrecision]:
+) -> List[QuantityDecimalPrecision]:
     """
     Returns a list of :class:`QuantityDecimalPrecision` objects for different
     types of instruments.
@@ -1025,7 +1025,7 @@ def get_quantity_decimal_precisions(
 def get_option_chain(
     session: Session,
     symbol: str
-) -> dict[date, list[Option]]:
+) -> Dict[date, List[Option]]:
     """
     Returns a mapping of expiration date to a list of option objects
     representing the options chain for the given symbol.
@@ -1062,7 +1062,7 @@ def get_option_chain(
 def get_future_option_chain(
     session: Session,
     symbol: str
-) -> dict[date, list[FutureOption]]:
+) -> Dict[date, List[FutureOption]]:
     """
     Returns a mapping of expiration date to a list of futures options
     objects representing the options chain for the given symbol.

--- a/tastytrade/metrics.py
+++ b/tastytrade/metrics.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Optional, List, Dict
+from typing import Any, Dict, List, Optional
 
 import requests
 

--- a/tastytrade/metrics.py
+++ b/tastytrade/metrics.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any, Optional, List, Dict
 
 import requests
 
@@ -65,7 +65,7 @@ class MarketMetricInfo(TastytradeJsonDataclass):
     liquidity_rank: Decimal
     liquidity_rating: int
     updated_at: datetime
-    option_expiration_implied_volatilities: list[OptionExpirationImpliedVolatility]  # noqa: E501
+    option_expiration_implied_volatilities: List[OptionExpirationImpliedVolatility]  # noqa: E501
     liquidity_running_state: Liquidity
     beta: Decimal
     beta_updated_at: datetime
@@ -92,8 +92,8 @@ class MarketMetricInfo(TastytradeJsonDataclass):
 
 def get_market_metrics(
     session: Session,
-    symbols: list[str]
-) -> list[MarketMetricInfo]:
+    symbols: List[str]
+) -> List[MarketMetricInfo]:
     """
     Retrieves market metrics for the given symbols.
 
@@ -114,7 +114,7 @@ def get_market_metrics(
     return [MarketMetricInfo(**entry) for entry in data]
 
 
-def get_dividends(session: Session, symbol: str) -> list[DividendInfo]:
+def get_dividends(session: Session, symbol: str) -> List[DividendInfo]:
     """
     Retrieves dividend information for the given symbol.
 
@@ -139,7 +139,7 @@ def get_earnings(
     session: Session,
     symbol: str,
     start_date: date
-) -> list[EarningsInfo]:
+) -> List[EarningsInfo]:
     """
     Retrieves earnings information for the given symbol.
 
@@ -150,7 +150,7 @@ def get_earnings(
     :return: a list of Tastytrade 'EarningsInfo' objects in JSON format.
     """
     symbol = symbol.replace('/', '%2F')
-    params: dict[str, Any] = {'start-date': start_date}
+    params: Dict[str, Any] = {'start-date': start_date}
     response = requests.get(
         f'{session.base_url}/market-metrics/historic-corporate-events/earnings-reports/{symbol}',  # noqa: E501
         headers=session.headers,

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
 
 from tastytrade import VERSION
 from tastytrade.utils import TastytradeJsonDataclass

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Optional
+from typing import Optional, List, Dict
 
 from tastytrade import VERSION
 from tastytrade.utils import TastytradeJsonDataclass
@@ -120,7 +120,7 @@ class Leg(TastytradeJsonDataclass):
     action: OrderAction
     quantity: Decimal
     remaining_quantity: Optional[Decimal] = None
-    fills: Optional[list[FillInfo]] = None
+    fills: Optional[List[FillInfo]] = None
 
 
 class TradeableTastytradeJsonDataclass(TastytradeJsonDataclass):
@@ -187,7 +187,7 @@ class OrderCondition(TastytradeJsonDataclass):
     is_threshold_based_on_notional: bool
     triggered_at: datetime
     triggered_value: Decimal
-    price_components: list[OrderConditionPriceComponent]
+    price_components: List[OrderConditionPriceComponent]
 
 
 class OrderRule(TastytradeJsonDataclass):
@@ -198,7 +198,7 @@ class OrderRule(TastytradeJsonDataclass):
     routed_at: datetime
     cancel_at: datetime
     cancelled_at: datetime
-    order_conditions: list[OrderCondition]
+    order_conditions: List[OrderCondition]
 
 
 class NewOrder(TastytradeJsonDataclass):
@@ -209,7 +209,7 @@ class NewOrder(TastytradeJsonDataclass):
     time_in_force: OrderTimeInForce
     order_type: OrderType
     source: str = f'tastyware/tastytrade:v{VERSION}'
-    legs: list[Leg]
+    legs: List[Leg]
     gtc_date: Optional[date] = None
     stop_trigger: Optional[Decimal] = None
     price: Optional[Decimal] = None  # optional for market orders
@@ -237,7 +237,7 @@ class PlacedOrder(TastytradeJsonDataclass):
     editable: bool
     edited: bool
     updated_at: datetime
-    legs: list[Leg]
+    legs: List[Leg]
     id: Optional[str] = None
     price: Optional[Decimal] = None
     price_effect: Optional[PriceEffect] = None
@@ -276,8 +276,8 @@ class ComplexOrder(TastytradeJsonDataclass):
     ratio_price_threshold: Decimal
     ratio_price_comparator: str
     ratio_price_is_threshold_based_on_notional: bool
-    related_orders: list[dict[str, str]]
-    orders: list[PlacedOrder]
+    related_orders: List[Dict[str, str]]
+    orders: List[PlacedOrder]
     trigger_order: PlacedOrder
 
 
@@ -325,8 +325,8 @@ class PlacedOrderResponse(TastytradeJsonDataclass):
     fee_calculation: FeeCalculation
     order: Optional[PlacedOrder] = None
     complex_order: Optional[ComplexOrder] = None
-    warnings: Optional[list[Message]] = None
-    errors: Optional[list[Message]] = None
+    warnings: Optional[List[Message]] = None
+    errors: Optional[List[Message]] = None
 
 
 class OrderChainEntry(TastytradeJsonDataclass):
@@ -369,8 +369,8 @@ class OrderChainNode(TastytradeJsonDataclass):
     fill_cost_per_quantity_effect: Optional[PriceEffect] = None
     order_fill_count: Optional[int] = None
     roll: Optional[bool] = None
-    legs: Optional[list[OrderChainLeg]] = None
-    entries: Optional[list[OrderChainEntry]] = None
+    legs: Optional[List[OrderChainLeg]] = None
+    entries: Optional[List[OrderChainEntry]] = None
 
 
 class ComputedData(TastytradeJsonDataclass):
@@ -403,7 +403,7 @@ class ComputedData(TastytradeJsonDataclass):
     total_cost_effect: PriceEffect
     gcd_open_quantity: Decimal
     fees_missing: bool
-    open_entries: list[OrderChainEntry]
+    open_entries: List[OrderChainEntry]
     total_cost_per_unit: Optional[Decimal] = None
     total_cost_per_unit_effect: Optional[PriceEffect] = None
 
@@ -422,4 +422,4 @@ class OrderChain(TastytradeJsonDataclass):
     underlying_symbol: str
     computed_data: ComputedData
     lite_nodes_sizes: int
-    lite_nodes: list[OrderChainNode]
+    lite_nodes: List[OrderChainNode]

--- a/tastytrade/search.py
+++ b/tastytrade/search.py
@@ -1,8 +1,10 @@
+from typing import List
+
 import requests
 
 from tastytrade.session import Session
 from tastytrade.utils import TastytradeJsonDataclass
-from typing import List
+
 
 class SymbolData(TastytradeJsonDataclass):
     """

--- a/tastytrade/search.py
+++ b/tastytrade/search.py
@@ -2,7 +2,7 @@ import requests
 
 from tastytrade.session import Session
 from tastytrade.utils import TastytradeJsonDataclass
-
+from typing import List
 
 class SymbolData(TastytradeJsonDataclass):
     """
@@ -12,7 +12,7 @@ class SymbolData(TastytradeJsonDataclass):
     description: str
 
 
-def symbol_search(session: Session, symbol: str) -> list[SymbolData]:
+def symbol_search(session: Session, symbol: str) -> List[SymbolData]:
     """
     Performs a symbol search using the Tastytrade API and returns a
     list of symbols that are similar to the given search phrase.

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
 
 import requests
 

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -40,7 +40,8 @@ class Session:
         elif remember_token:
             body['remember-token'] = remember_token
         else:
-            print("Error: you must provide a password or remember token to log in.")
+            print("Error: you must provide a password or remember "
+                  "token to log in.")
         #: The base url to use for API requests
         self.base_url: str = CERT_URL if is_certification else API_URL
         #: Whether or not this session is using the certification API

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -25,16 +25,22 @@ class Session:
     def __init__(
         self,
         login: str,
-        password: str,
+        password: str = None,
+        remember_token: str = None,
         remember_me: bool = False,
         two_factor_authentication: str = '',
         is_certification: bool = False
     ):
         body = {
             'login': login,
-            'password': password,
             'remember-me': remember_me
         }
+        if password:
+            body['password'] = password
+        elif remember_token:
+            body['remember-token'] = remember_token
+        else:
+            print("Error: you must provide a password or remember token to log in.")
         #: The base url to use for API requests
         self.base_url: str = CERT_URL if is_certification else API_URL
         #: Whether or not this session is using the certification API

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 
 import requests
 
@@ -89,7 +89,7 @@ class Session:
         )
         return (response.status_code // 100 == 2)
 
-    def get_customer(self) -> dict[str, Any]:
+    def get_customer(self) -> Dict[str, Any]:
         """
         Gets the customer dict from the API.
 

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -4,7 +4,7 @@ from asyncio import Lock, Queue
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, AsyncIterator, Optional, Union, List, Dict
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 import requests
 import websockets

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -4,7 +4,7 @@ from asyncio import Lock, Queue
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, AsyncIterator, Optional, Union
+from typing import Any, AsyncIterator, Optional, Union, List, Dict
 
 import requests
 import websockets
@@ -189,7 +189,7 @@ class AlertStreamer:
         else:
             raise TastytradeError(f'Unknown message type: {type_str}\n{data}')
 
-    async def account_subscribe(self, accounts: list[Account]) -> None:
+    async def account_subscribe(self, accounts: List[Account]) -> None:
         """
         Subscribes to account-level updates (balances, orders, positions).
 
@@ -239,13 +239,13 @@ class AlertStreamer:
     async def _subscribe(
         self,
         subscription: SubscriptionType,
-        value: Union[Optional[str], list[str]] = ''
+        value: Union[Optional[str], List[str]] = ''
     ) -> None:
         """
         Subscribes to a :class:`SubscriptionType`. Depending on the kind of
         subscription, the value parameter may be required.
         """
-        message: dict[str, Any] = {
+        message: Dict[str, Any] = {
             'auth-token': self.token,
             'action': subscription
         }
@@ -439,7 +439,7 @@ class DataStreamer:
     async def subscribe(
         self,
         event_type: EventType,
-        symbols: list[str],
+        symbols: List[str],
         reset: bool = False
     ) -> None:
         """
@@ -468,7 +468,7 @@ class DataStreamer:
     async def unsubscribe(
         self,
         event_type: EventType,
-        symbols: list[str]
+        symbols: List[str]
     ) -> None:
         """
         Removes existing subscription for given list of symbols.
@@ -540,7 +540,7 @@ class DataStreamer:
         logger.debug('sending unsubscription: %s', message)
         await self._websocket.send(json.dumps([message]))
 
-    def _map_message(self, message) -> list[Event]:
+    def _map_message(self, message) -> List[Event]:
         """
         Takes the raw JSON data and returns a list of parsed event objects.
         """

--- a/tastytrade/watchlists.py
+++ b/tastytrade/watchlists.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List, Dict
 
 import requests
 
@@ -25,10 +25,10 @@ class PairsWatchlist(TastytradeJsonDataclass):
     """
     name: str
     order_index: int
-    pairs_equations: list[Pair]
+    pairs_equations: List[Pair]
 
     @classmethod
-    def get_pairs_watchlists(cls, session: Session) -> list['PairsWatchlist']:
+    def get_pairs_watchlists(cls, session: Session) -> List['PairsWatchlist']:
         """
         Fetches a list of all Tastytrade public pairs watchlists.
 
@@ -76,7 +76,7 @@ class Watchlist(TastytradeJsonDataclass):
     with functions to update, publish, modify and remove watchlists.
     """
     name: str
-    watchlist_entries: Optional[list[dict[str, str]]] = None
+    watchlist_entries: Optional[List[Dict[str, str]]] = None
     group_name: str = 'default'
     order_index: int = 9999
 
@@ -85,7 +85,7 @@ class Watchlist(TastytradeJsonDataclass):
         cls,
         session: Session,
         counts_only: bool = False
-    ) -> list['Watchlist']:
+    ) -> List['Watchlist']:
         """
         Fetches a list of all Tastytrade public watchlists.
 
@@ -126,7 +126,7 @@ class Watchlist(TastytradeJsonDataclass):
         return cls(**data)
 
     @classmethod
-    def get_private_watchlists(cls, session: Session) -> list['Watchlist']:
+    def get_private_watchlists(cls, session: Session) -> List['Watchlist']:
         """
         Fetches a the user's private watchlists.
 

--- a/tastytrade/watchlists.py
+++ b/tastytrade/watchlists.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
 
 import requests
 


### PR DESCRIPTION
I was unable to successfully install the module with `pip install tastytrade`. Several attributes of the tastytrade module simply did not appear. I made changes by importing these missing attributes in the tastytrade/__init__.py. I also had to change the way the typing library was incorporated, because built-in type objects like list and dict are not subscriptable; `def fun(self) -> list[str]:` is illegal; `typing.List[str]` must be used instead.

The previous version of the Session constructor also did not allow for the use of a remember token. The documentation incorrectly stated that it did. In reality, if a remember token was provided, the request still sent the remember token as the password, which was incorrect. I changed the Session constructor to allow for either login method. If I'm not mistaken, there are currently no calls to the Session constructor that exist in the code, so this shouldn't be a problem.