### PR TITLE
Made some attributes optional - #76

### DIFF
--- a/tastytrade/metrics.py
+++ b/tastytrade/metrics.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import requests
 
@@ -61,20 +61,20 @@ class MarketMetricInfo(TastytradeJsonDataclass):
     implied_volatility_index_rank_source: str
     implied_volatility_percentile: Decimal
     implied_volatility_updated_at: datetime
-    liquidity_value: Decimal
-    liquidity_rank: Decimal
+    liquidity_value: Optional[Decimal]
+    liquidity_rank: Optional[Decimal]
     liquidity_rating: int
     updated_at: datetime
-    option_expiration_implied_volatilities: List[OptionExpirationImpliedVolatility]  # noqa: E501
-    liquidity_running_state: Liquidity
+    option_expiration_implied_volatilities: list[OptionExpirationImpliedVolatility]
+    liquidity_running_state: Optional[Liquidity]
     beta: Decimal
-    beta_updated_at: datetime
+    beta_updated_at: Optional[datetime]
     corr_spy_3month: Decimal
     dividend_rate_per_share: Decimal
-    dividend_yield: Decimal
-    listed_market: str
-    lendability: str
-    borrow_rate: Decimal
+    dividend_yield: Optional[Decimal]
+    listed_market: Optional[str]
+    lendability: Optional[str]
+    borrow_rate: Optional[Decimal]
     market_cap: Decimal
     implied_volatility_30_day: Decimal
     historical_volatility_30_day: Decimal
@@ -83,17 +83,13 @@ class MarketMetricInfo(TastytradeJsonDataclass):
     iv_hv_30_day_difference: Decimal
     price_earnings_ratio: Decimal
     earnings_per_share: Decimal
-    created_at: Optional[datetime] = None
     dividend_ex_date: Optional[date] = None
     dividend_next_date: Optional[date] = None
     dividend_pay_date: Optional[date] = None
     dividend_updated_at: Optional[datetime] = None
 
 
-def get_market_metrics(
-    session: Session,
-    symbols: List[str]
-) -> List[MarketMetricInfo]:
+def get_market_metrics(session: Session, symbols: list[str]) -> list[MarketMetricInfo]:
     """
     Retrieves market metrics for the given symbols.
 
@@ -114,7 +110,7 @@ def get_market_metrics(
     return [MarketMetricInfo(**entry) for entry in data]
 
 
-def get_dividends(session: Session, symbol: str) -> List[DividendInfo]:
+def get_dividends(session: Session, symbol: str) -> list[DividendInfo]:
     """
     Retrieves dividend information for the given symbol.
 
@@ -125,7 +121,7 @@ def get_dividends(session: Session, symbol: str) -> List[DividendInfo]:
     """
     symbol = symbol.replace('/', '%2F')
     response = requests.get(
-        f'{session.base_url}/market-metrics/historic-corporate-events/dividends/{symbol}',  # noqa: E501
+        f'{session.base_url}/market-metrics/historic-corporate-events/dividends/{symbol}',
         headers=session.headers
     )
     validate_response(response)
@@ -135,11 +131,7 @@ def get_dividends(session: Session, symbol: str) -> List[DividendInfo]:
     return [DividendInfo(**entry) for entry in data]
 
 
-def get_earnings(
-    session: Session,
-    symbol: str,
-    start_date: date
-) -> List[EarningsInfo]:
+def get_earnings(session: Session, symbol: str, start_date: date) -> list[EarningsInfo]:
     """
     Retrieves earnings information for the given symbol.
 
@@ -150,9 +142,9 @@ def get_earnings(
     :return: a list of Tastytrade 'EarningsInfo' objects in JSON format.
     """
     symbol = symbol.replace('/', '%2F')
-    params: Dict[str, Any] = {'start-date': start_date}
+    params: dict[str, Any] = {'start-date': start_date}
     response = requests.get(
-        f'{session.base_url}/market-metrics/historic-corporate-events/earnings-reports/{symbol}',  # noqa: E501
+        f'{session.base_url}/market-metrics/historic-corporate-events/earnings-reports/{symbol}',
         headers=session.headers,
         params=params
     )
@@ -161,21 +153,3 @@ def get_earnings(
     data = response.json()['data']['items']
 
     return [EarningsInfo(**entry) for entry in data]
-
-
-def get_risk_free_rate(session: Session) -> Decimal:
-    """
-    Retrieves the current risk-free rate.
-
-    :param session: active user session to use
-
-    :return: the current risk-free rate
-    """
-    response = requests.get(
-        f'{session.base_url}/margin-requirements-public-configuration',
-        headers=session.headers
-    )
-    validate_response(response)
-
-    data = response.json()['data']['risk-free-rate']
-    return Decimal(data)


### PR DESCRIPTION
For some symbols not all attributes from the MarketMetricInfo class are returned, those are now made optional

## Description

## Related issue(s)
Fixes ...

## Pre-merge checklist
- [ ] Passing tests
- [ ] New tests added (if applicable)
