### PR TITLE
enhanced-fraud-safeguards-enabled-at fix

### DIFF
--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -298,7 +298,6 @@ class TradingStatus(TastytradeJsonDataclass):
     small_notional_futures_margin_rate_multiplier: Decimal
     is_equity_offering_enabled: bool
     is_equity_offering_closing_only: bool
-    enhanced_fraud_safeguards_enabled_at: datetime
     updated_at: datetime
     day_trade_count: Optional[int] = None
     autotrade_account_type: Optional[str] = None
@@ -307,6 +306,7 @@ class TradingStatus(TastytradeJsonDataclass):
     is_cryptocurrency_closing_only: Optional[bool] = None
     pdt_reset_on: Optional[date] = None
     cmta_override: Optional[int] = None
+    enhanced_fraud_safeguards_enabled_at: Optional[datetime] = None
 
 
 class Transaction(TastytradeJsonDataclass):


### PR DESCRIPTION
## Description

bugfix TradingStatus Class

## Related issue(s)

enhanced_fraud_safeguards_enabled_at: can return nothing in the get request.
This just moves it to optional.

issue can be reproduced with this code
```
def day_trade_check(tt: ProductionSession, acct: Account, cash_balance, loop=None):
    trading_status = acct.get_trading_status(tt)
    day_trade_count = trading_status.day_trade_count
    if (
        acct.margin_or_cash == "Margin"
        and float(cash_balance) <= 25000
        and day_trade_count > 3
    ):
        print(
            f"Tastytrade account {acct.account_number}: day trade count is {day_trade_count}. More than 3 day trades will cause a strike on your account!"
        )
        return False
    return True


```
Tested with success

## Pre-merge checklist
-  [x] Passing tests
- [ ] New tests added (if applicable)
