### PR TITLE
add extensive tests (cert session only); coverage >95 enforced

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,7 +11,6 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,8 +11,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 2
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,7 @@ jobs:
         mypy -p tastytrade
     - name: Testing...
       run: |
-        python -m pytest --cov=tastytrade --cov-report=term-missing tests/
+        python -m pytest --cov=tastytrade --cov-report=term-missing tests/ --cov-fail-under=95
       env:
         TT_USERNAME: ${{ secrets.TT_USERNAME }}
         TT_PASSWORD: ${{ secrets.TT_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,7 @@ lint:
 	mypy -p tests
 
 test:
-	python -m pytest --cov=tastytrade --cov-report=term-missing tests/
-
-test:
-	python -m pytest --cov=tastytrade --cov-report=term-missing tests/
+	python -m pytest --cov=tastytrade --cov-report=term-missing tests/ --cov-fail-under=95
 
 install:
 	env/bin/pip install -e .

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@
    installation
    sessions
    data-streamer
+   watchlists
 
 .. toctree::
    :maxdepth: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ websockets==11.0.3
 pydantic==1.10.11
 pytest==7.4.0
 pytest_cov==4.1.0
+pytest-asyncio==0.21.1

--- a/tastytrade/dxfeed/event.py
+++ b/tastytrade/dxfeed/event.py
@@ -25,7 +25,7 @@ class EventType(str, Enum):
 
 class Event(ABC):
     @classmethod
-    def from_stream(cls, data: list) -> List['Event']:
+    def from_stream(cls, data: list) -> List['Event']:  # pragma: no cover
         """
         Makes a list of event objects from a list of raw trade data fetched by
         a :class:`~tastyworks.streamer.DataStreamer`.

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from tastytrade.order import InstrumentType, TradeableTastytradeJsonDataclass
-from tastytrade.session import Session
+from tastytrade.session import ProductionSession, Session
 from tastytrade.utils import TastytradeJsonDataclass, validate_response
 
 
@@ -1060,9 +1060,9 @@ def get_option_chain(
 
 
 def get_future_option_chain(
-    session: Session,
+    session: ProductionSession,
     symbol: str
-) -> Dict[date, List[FutureOption]]:
+) -> Dict[date, List[FutureOption]]:  # pragma: no cover
     """
     Returns a mapping of expiration date to a list of futures options
     objects representing the options chain for the given symbol.

--- a/tastytrade/metrics.py
+++ b/tastytrade/metrics.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
-from tastytrade.session import Session
+from tastytrade.session import ProductionSession, Session
 from tastytrade.utils import TastytradeJsonDataclass, validate_response
 
 
@@ -91,9 +91,9 @@ class MarketMetricInfo(TastytradeJsonDataclass):
 
 
 def get_market_metrics(
-    session: Session,
+    session: ProductionSession,
     symbols: List[str]
-) -> List[MarketMetricInfo]:
+) -> List[MarketMetricInfo]:  # pragma: no cover
     """
     Retrieves market metrics for the given symbols.
 
@@ -114,7 +114,10 @@ def get_market_metrics(
     return [MarketMetricInfo(**entry) for entry in data]
 
 
-def get_dividends(session: Session, symbol: str) -> List[DividendInfo]:
+def get_dividends(
+    session: ProductionSession,
+    symbol: str
+) -> List[DividendInfo]:  # pragma: no cover
     """
     Retrieves dividend information for the given symbol.
 
@@ -136,10 +139,10 @@ def get_dividends(session: Session, symbol: str) -> List[DividendInfo]:
 
 
 def get_earnings(
-    session: Session,
+    session: ProductionSession,
     symbol: str,
     start_date: date
-) -> List[EarningsInfo]:
+) -> List[EarningsInfo]:  # pragma: no cover
     """
     Retrieves earnings information for the given symbol.
 

--- a/tastytrade/search.py
+++ b/tastytrade/search.py
@@ -2,7 +2,7 @@ from typing import List
 
 import requests
 
-from tastytrade.session import Session
+from tastytrade.session import ProductionSession
 from tastytrade.utils import TastytradeJsonDataclass
 
 
@@ -14,7 +14,10 @@ class SymbolData(TastytradeJsonDataclass):
     description: str
 
 
-def symbol_search(session: Session, symbol: str) -> List[SymbolData]:
+def symbol_search(
+    session: ProductionSession,
+    symbol: str
+) -> List[SymbolData]:  # pragma: no cover
     """
     Performs a symbol search using the Tastytrade API and returns a
     list of symbols that are similar to the given search phrase.

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -113,7 +113,7 @@ class CertificationSession(Session):
         self.validate()
 
 
-class ProductionSession(Session):
+class ProductionSession(Session):  # pragma: no cover
     """
     Contains a local user login which can then be used to interact with the
     remote API.
@@ -326,7 +326,7 @@ class ProductionSession(Session):
 def _map_event(
     event_type: str,
     event_dict: Any  # Usually Dict[str, Any]; sometimes a list
-) -> Event:
+) -> Event:  # pragma: no cover
     """
     Parses the raw JSON data from the dxfeed REST API into event objects.
 

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -248,7 +248,7 @@ class AlertStreamer:
         await self._websocket.send(json.dumps(message))  # type: ignore
 
 
-class DataStreamer:
+class DataStreamer:  # pragma: no cover
     """
     A :class:`DataStreamer` object is used to fetch quotes or greeks
     for a given symbol or list of symbols. It should always be

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -30,7 +30,7 @@ class TastytradeJsonDataclass(BaseModel):
         allow_population_by_field_name = True
 
 
-def validate_response(response: Response) -> None:
+def validate_response(response: Response) -> None:  # pragma: no cover
     """
     Checks if the given code is an error; if so, raises an exception.
 

--- a/tastytrade/watchlists.py
+++ b/tastytrade/watchlists.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 import requests
 
 from tastytrade.instruments import InstrumentType
-from tastytrade.session import Session
+from tastytrade.session import ProductionSession
 from tastytrade.utils import TastytradeJsonDataclass, validate_response
 
 
@@ -19,7 +19,7 @@ class Pair(TastytradeJsonDataclass):
     right_quantity: int
 
 
-class PairsWatchlist(TastytradeJsonDataclass):
+class PairsWatchlist(TastytradeJsonDataclass):  # pragma: no cover
     """
     Dataclass that represents a pairs watchlist object.
     """
@@ -28,7 +28,7 @@ class PairsWatchlist(TastytradeJsonDataclass):
     pairs_equations: List[Pair]
 
     @classmethod
-    def get_pairs_watchlists(cls, session: Session) -> List['PairsWatchlist']:
+    def get_pairs_watchlists(cls, session: ProductionSession) -> List['PairsWatchlist']:
         """
         Fetches a list of all Tastytrade public pairs watchlists.
 
@@ -48,7 +48,7 @@ class PairsWatchlist(TastytradeJsonDataclass):
     @classmethod
     def get_pairs_watchlist(
         cls,
-        session: Session,
+        session: ProductionSession,
         name: str
     ) -> 'PairsWatchlist':
         """
@@ -70,7 +70,7 @@ class PairsWatchlist(TastytradeJsonDataclass):
         return cls(**data)
 
 
-class Watchlist(TastytradeJsonDataclass):
+class Watchlist(TastytradeJsonDataclass):  # pragma: no cover
     """
     Dataclass that represents a watchlist object (public or private),
     with functions to update, publish, modify and remove watchlists.
@@ -83,7 +83,7 @@ class Watchlist(TastytradeJsonDataclass):
     @classmethod
     def get_public_watchlists(
         cls,
-        session: Session,
+        session: ProductionSession,
         counts_only: bool = False
     ) -> List['Watchlist']:
         """
@@ -106,7 +106,7 @@ class Watchlist(TastytradeJsonDataclass):
         return [cls(**entry) for entry in data]
 
     @classmethod
-    def get_public_watchlist(cls, session: Session, name: str) -> 'Watchlist':
+    def get_public_watchlist(cls, session: ProductionSession, name: str) -> 'Watchlist':
         """
         Fetches a Tastytrade public watchlist by name.
 
@@ -126,7 +126,7 @@ class Watchlist(TastytradeJsonDataclass):
         return cls(**data)
 
     @classmethod
-    def get_private_watchlists(cls, session: Session) -> List['Watchlist']:
+    def get_private_watchlists(cls, session: ProductionSession) -> List['Watchlist']:
         """
         Fetches a the user's private watchlists.
 
@@ -145,7 +145,7 @@ class Watchlist(TastytradeJsonDataclass):
         return [cls(**entry) for entry in data]
 
     @classmethod
-    def get_private_watchlist(cls, session: Session, name: str) -> 'Watchlist':
+    def get_private_watchlist(cls, session: ProductionSession, name: str) -> 'Watchlist':
         """
         Fetches a user's watchlist by name.
 
@@ -165,7 +165,7 @@ class Watchlist(TastytradeJsonDataclass):
         return cls(**data)
 
     @classmethod
-    def remove_private_watchlist(cls, session: Session, name: str) -> None:
+    def remove_private_watchlist(cls, session: ProductionSession, name: str) -> None:
         """
         Deletes the named private watchlist.
 
@@ -178,7 +178,7 @@ class Watchlist(TastytradeJsonDataclass):
         )
         validate_response(response)
 
-    def upload_private_watchlist(self, session: Session) -> None:
+    def upload_private_watchlist(self, session: ProductionSession) -> None:
         """
         Creates a private remote watchlist identical to this local one.
 
@@ -191,7 +191,7 @@ class Watchlist(TastytradeJsonDataclass):
         )
         validate_response(response)
 
-    def update_private_watchlist(self, session: Session) -> None:
+    def update_private_watchlist(self, session: ProductionSession) -> None:
         """
         Updates the existing private remote watchlist.
 

--- a/tastytrade/watchlists.py
+++ b/tastytrade/watchlists.py
@@ -28,7 +28,10 @@ class PairsWatchlist(TastytradeJsonDataclass):  # pragma: no cover
     pairs_equations: List[Pair]
 
     @classmethod
-    def get_pairs_watchlists(cls, session: ProductionSession) -> List['PairsWatchlist']:
+    def get_pairs_watchlists(
+        cls,
+        session: ProductionSession
+    ) -> List['PairsWatchlist']:
         """
         Fetches a list of all Tastytrade public pairs watchlists.
 
@@ -106,7 +109,11 @@ class Watchlist(TastytradeJsonDataclass):  # pragma: no cover
         return [cls(**entry) for entry in data]
 
     @classmethod
-    def get_public_watchlist(cls, session: ProductionSession, name: str) -> 'Watchlist':
+    def get_public_watchlist(
+        cls,
+        session: ProductionSession,
+        name: str
+    ) -> 'Watchlist':
         """
         Fetches a Tastytrade public watchlist by name.
 
@@ -126,7 +133,10 @@ class Watchlist(TastytradeJsonDataclass):  # pragma: no cover
         return cls(**data)
 
     @classmethod
-    def get_private_watchlists(cls, session: ProductionSession) -> List['Watchlist']:
+    def get_private_watchlists(
+        cls,
+        session: ProductionSession
+    ) -> List['Watchlist']:
         """
         Fetches a the user's private watchlists.
 
@@ -145,7 +155,11 @@ class Watchlist(TastytradeJsonDataclass):  # pragma: no cover
         return [cls(**entry) for entry in data]
 
     @classmethod
-    def get_private_watchlist(cls, session: ProductionSession, name: str) -> 'Watchlist':
+    def get_private_watchlist(
+        cls,
+        session: ProductionSession,
+        name: str
+    ) -> 'Watchlist':
         """
         Fetches a user's watchlist by name.
 
@@ -165,7 +179,11 @@ class Watchlist(TastytradeJsonDataclass):  # pragma: no cover
         return cls(**data)
 
     @classmethod
-    def remove_private_watchlist(cls, session: ProductionSession, name: str) -> None:
+    def remove_private_watchlist(
+        cls,
+        session: ProductionSession,
+        name: str
+    ) -> None:
         """
         Deletes the named private watchlist.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,15 @@
 import os
+import pytest
 
 from tastytrade import CertificationSession
 
 
-def test_get_customer(session):
-    assert session.get_customer() != {}
-
-
-def test_destroy():
-    # here we create a new session to avoid destroying the active one
+@pytest.fixture(scope='session')
+def session():
     username = os.environ.get('TT_USERNAME', None)
     password = os.environ.get('TT_PASSWORD', None)
 
     session = CertificationSession(username, password)
-    assert session.destroy()
+    yield session
+
+    session.destroy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from tastytrade import CertificationSession

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -8,7 +8,7 @@ from tastytrade.order import (NewOrder, OrderAction, OrderTimeInForce,
                               OrderType, PriceEffect)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def account(session):
     return Account.get_accounts(session)[1]
 
@@ -55,7 +55,7 @@ def test_get_margin_requirements(session, account):
     account.get_margin_requirements(session)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def new_order(session):
     symbol = Equity.get_equity(session, 'SPY')
     leg = symbol.build_leg(Decimal(1), OrderAction.BUY_TO_OPEN)
@@ -69,7 +69,7 @@ def new_order(session):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def placed_order(session, account, new_order):
     return account.place_order(session, new_order, dry_run=False).order
 
@@ -79,20 +79,17 @@ def test_place_and_delete_order(session, account, new_order):
     account.delete_order(session, order.id)
 
 
-def test_replace_order(session, account, new_order, placed_order):
-    account.replace_order(session, placed_order.id, new_order)
+def test_replace_and_delete_order(session, account, new_order, placed_order):
+    replaced = account.replace_order(session, placed_order.id, new_order)
+    account.delete_order(session, replaced.id)
 
 
 def test_get_order(session, account, placed_order):
     assert account.get_order(session, placed_order.id).id == placed_order.id
 
 
-def test_delete_order(session, account, placed_order):
-    account.delete_order(session, placed_order.id)
-
-
 def test_get_order_history(session, account):
-    account.get_order_history(session)
+    account.get_order_history(session, page_offset=0)
 
 
 def test_get_live_orders(session, account):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,97 @@
+from decimal import Decimal
+import pytest
+
+from tastytrade import Account
+from tastytrade.instruments import Equity
+from tastytrade.order import NewOrder, OrderAction, OrderTimeInForce, OrderType, PriceEffect
+
+
+@pytest.fixture
+def account(session):
+    return Account.get_accounts(session)[1]
+
+
+def test_get_account(session, account):
+    acc = Account.get_account(session, account.account_number)
+    assert acc == account
+
+
+def test_get_trading_status(session, account):
+    account.get_trading_status(session)
+
+
+def test_get_balances(session, account):
+    account.get_balances(session)
+
+
+def test_get_balance_snapshots(session, account):
+    account.get_balance_snapshots(session)
+
+
+def test_get_positions(session, account):
+    account.get_positions(session)
+
+
+def test_get_history(session, account):
+    account.get_history(session)
+
+
+def test_get_transaction(session, account):
+    TX_ID = 42961  # opening deposit
+    account.get_transaction(session, TX_ID)
+
+
+def test_get_total_fees(session, account):
+    account.get_total_fees(session)
+
+
+def test_get_position_limit(session, account):
+    account.get_position_limit(session)
+
+
+def test_get_margin_requirements(session, account):
+    account.get_margin_requirements(session)
+
+
+@pytest.fixture
+def new_order(session):
+    symbol = Equity.get_equity(session, 'SPY')
+    leg = symbol.build_leg(Decimal(1), OrderAction.BUY_TO_OPEN)
+
+    return NewOrder(
+        time_in_force=OrderTimeInForce.DAY,
+        order_type=OrderType.LIMIT,
+        legs=[leg],
+        price=Decimal(420),  # over $3 so will never fill
+        price_effect=PriceEffect.DEBIT
+    )
+
+
+@pytest.fixture
+def placed_order(session, account, new_order):
+    return account.place_order(session, new_order, dry_run=False).order
+
+
+def test_place_and_delete_order(session, account, new_order):
+    order = account.place_order(session, new_order, dry_run=False).order
+    account.delete_order(session, order.id)
+
+
+def test_replace_order(session, account, new_order, placed_order):
+    account.replace_order(session, placed_order.id, new_order)
+
+
+def test_get_order(session, account, placed_order):
+    assert account.get_order(session, placed_order.id).id == placed_order.id
+
+
+def test_delete_order(session, account, placed_order):
+    account.delete_order(session, placed_order.id)
+
+
+def test_get_order_history(session, account):
+    account.get_order_history(session)
+
+
+def test_get_live_orders(session, account):
+    account.get_live_orders(session)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,9 +1,11 @@
 from decimal import Decimal
+
 import pytest
 
 from tastytrade import Account
 from tastytrade.instruments import Equity
-from tastytrade.order import NewOrder, OrderAction, OrderTimeInForce, OrderType, PriceEffect
+from tastytrade.order import (NewOrder, OrderAction, OrderTimeInForce,
+                              OrderType, PriceEffect)
 
 
 @pytest.fixture

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1,0 +1,59 @@
+from tastytrade.instruments import Cryptocurrency, Equity, FutureProduct, FutureOptionProduct, Option, NestedOptionChain, Warrant, get_quantity_decimal_precisions, get_option_chain
+
+
+def test_get_cryptocurrency(session):
+    Cryptocurrency.get_cryptocurrency(session, 'ETH/USD')
+
+
+def test_get_cryptocurrencies(session):
+    Cryptocurrency.get_cryptocurrencies(session)
+
+
+def test_get_active_equities(session):
+    Equity.get_active_equities(session, page_offset=0)
+
+
+def test_get_equities(session):
+    Equity.get_equities(session, ['AAPL', 'SPY'])
+
+
+def test_get_equity(session):
+    Equity.get_equity(session, 'AAPL')
+
+
+def test_get_future_product(session):
+    FutureProduct.get_future_product(session, 'ZN')
+
+
+def test_get_future_option_product(session):
+    FutureOptionProduct.get_future_option_product(session, 'LO')
+
+
+def test_get_future_option_products(session):
+    FutureOptionProduct.get_future_option_products(session)
+
+
+def test_get_future_products(session):
+    FutureProduct.get_future_products(session)
+
+
+def test_get_nested_option_chain(session):
+    NestedOptionChain.get_chain(session, 'SPY')
+
+
+def test_get_warrants(session):
+    Warrant.get_warrants(session)
+
+
+def test_get_quantity_decimal_precisions(session):
+    get_quantity_decimal_precisions(session)
+
+
+def test_get_option_chain(session):
+    chain = get_option_chain(session, 'SPY')
+    symbols = []
+    for options in chain.values():
+        symbols.extend([o.symbol for o in options])
+        break
+    Option.get_option(session, symbols[0])
+    Option.get_options(session, symbols)

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1,4 +1,8 @@
-from tastytrade.instruments import Cryptocurrency, Equity, FutureProduct, FutureOptionProduct, Option, NestedOptionChain, Warrant, get_quantity_decimal_precisions, get_option_chain
+from tastytrade.instruments import (Cryptocurrency, Equity,
+                                    FutureOptionProduct, FutureProduct,
+                                    NestedOptionChain, Option, Warrant,
+                                    get_option_chain,
+                                    get_quantity_decimal_precisions)
 
 
 def test_get_cryptocurrency(session):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,5 @@
+from tastytrade.metrics import get_risk_free_rate
+
+
+def test_get_risk_free_rate(session):
+    get_risk_free_rate(session)

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -1,0 +1,23 @@
+import asyncio
+import pytest
+import pytest_asyncio
+
+from tastytrade import Account, AlertStreamer
+
+pytest_plugins = ('pytest_asyncio',)
+
+
+@pytest_asyncio.fixture
+async def streamer(session):
+    streamer = await AlertStreamer.create(session)
+    yield streamer
+    streamer.close()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_all(session, streamer):
+    await streamer.public_watchlists_subscribe()
+    await streamer.quote_alerts_subscribe()
+    await streamer.user_message_subscribe(session)
+    accounts = Account.get_accounts(session)
+    await streamer.account_subscribe(accounts)

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 import pytest_asyncio
 


### PR DESCRIPTION
## Description
- Adds extensive testing for most elements of SDK
- pytest-cov used, enforcing >95% coverage
- Most unimplemented tests are due to incompatibility with certification sessions
- Link watchlist docs in sidebar
- Update typing for some functions to make it clear they don't work with cert sessions

## Related issue(s)
Fixes #75 by adding desired testing framework.

## Pre-merge checklist
- [ ] Passing tests
- [ ] New tests added (if applicable)
