### PR TITLE
streamers use async context managers; prod session in testing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Secrets are protected by Github and are not visible to anyone. You can read more
 
 1. Fork the repository to your personal Github account, NOT to an organization where others may be able to indirectly access your secrets.
 2. Make your changes on the forked repository.
-3. Navigate to the forked repository's settings page and click on "Secrets and variables" > "Actions".
-4. Click on "New repository secret" to add your Tastytrade username named `TT_USERNAME`.
-5. Finally, do the same with your password, naming it `TT_PASSWORD`.
+3. Go to the "Actions" page on the forked repository and enable actions.
+4. Navigate to the forked repository's settings page and click on "Secrets and variables" > "Actions".
+5. Click on "New repository secret" to add your Tastytrade username named `TT_USERNAME`.
+6. Finally, do the same with your password, naming it `TT_PASSWORD`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributions
+
+Since Tastytrade certification sessions are severely limited in capabilities, the test suite for this SDK requires the usage of your own Tastytrade credentials. In order to run the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork.
+
+Secrets are protected by Github and are not visible to anyone. You can read more about repository secrets [here](https://docs.github.com/en/actions/reference/encrypted-secrets).
+
+## Steps to follow to contribute
+
+1. Fork the repository to your personal Github account, NOT to an organization where others may be able to indirectly access your secrets.
+2. Make your changes on the forked repository.
+3. Navigate to the forked repository's settings page and click on "Secrets and variables" > "Actions".
+4. Click on "New repository secret" to add your Tastytrade username named `TT_USERNAME`.
+5. Finally, do the same with your password, naming it `TT_PASSWORD`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,5 @@ Fixes ...
 ## Pre-merge checklist
 - [ ] Passing tests
 - [ ] New tests added (if applicable)
+
+Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 Fixes ...
 
 ## Pre-merge checklist
-- [ ] Passing tests
+- [ ] Passing tests LOCALLY
 - [ ] New tests added (if applicable)
 
 Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,8 +3,6 @@ name: Python application
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,16 +10,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -33,5 +30,5 @@ jobs:
       run: |
         python -m pytest --cov=tastytrade --cov-report=term-missing tests/ --cov-fail-under=95
       env:
-        TT_USERNAME: tastyware
-        TT_PASSWORD: :4s-S9/9L&Q~C]@v
+        TT_USERNAME: ${{ secrets.TT_USERNAME }}
+        TT_PASSWORD: ${{ secrets.TT_PASSWORD }}

--- a/README.rst
+++ b/README.rst
@@ -40,20 +40,19 @@ The streamer is a websocket connection to dxfeed (the Tastytrade data provider) 
 
 .. code-block:: python
 
-   from tastytrade import DXFeedStreamer
+   from tastytrade import DXLinkStreamer
    from tastytrade.dxfeed import EventType
 
-   streamer = await DXFeedStreamer.create(session)
-   subs_list = ['SPY', 'SPX']
-
-   await streamer.subscribe(EventType.QUOTE, subs_list)
-   # this example fetches quotes once, then exits
-   quotes = []
-   async for quote in streamer.listen(EventType.QUOTE):
-      quotes.append(quote)
-      if len(quotes) >= len(subs_list):
-         break
-   print(quotes)
+   async with DXLinkStreamer(session) as streamer:
+      subs_list = ['SPY', 'GLD']  # list of symbols to subscribe to
+      await streamer.subscribe(EventType.QUOTE, subs_list)
+      # this example fetches quotes once, then exits
+      quotes = []
+      async for quote in streamer.listen(EventType.QUOTE):
+         quotes.append(quote)
+         if len(quotes) >= len(subs_list):
+            break
+      print(quotes)
 
 >>> [Quote(eventSymbol='SPY', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='Q', bidPrice=411.58, bidSize=400.0, askTime=0, askExchangeCode='Q', askPrice=411.6, askSize=1313.0), Quote(eventSymbol='SPX', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='\x00', bidPrice=4122.49, bidSize='NaN', askTime=0, askExchangeCode='\x00', askPrice=4123.65, askSize='NaN')]
 

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -668,7 +668,11 @@ class Account(TastytradeJsonDataclass):
 
         return [Transaction(**entry) for entry in results]
 
-    def get_transaction(self, session: Session, id: int) -> Transaction:  # pragma: no cover
+    def get_transaction(
+        self,
+        session: Session,
+        id: int
+    ) -> Transaction:  # pragma: no cover
         """
         Get a single transaction by ID.
 

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -295,7 +295,6 @@ class TradingStatus(TastytradeJsonDataclass):
     is_in_margin_call: bool
     is_pattern_day_trader: bool
     is_portfolio_margin_enabled: bool
-    is_risk_reducing_only: bool
     is_small_notional_futures_intra_day_enabled: bool
     is_roll_the_day_forward_enabled: bool
     are_far_otm_net_options_restricted: bool
@@ -305,6 +304,7 @@ class TradingStatus(TastytradeJsonDataclass):
     is_equity_offering_enabled: bool
     is_equity_offering_closing_only: bool
     updated_at: datetime
+    is_risk_reducing_only: Optional[bool] = None
     day_trade_count: Optional[int] = None
     autotrade_account_type: Optional[str] = None
     clearing_account_number: Optional[str] = None
@@ -668,7 +668,7 @@ class Account(TastytradeJsonDataclass):
 
         return [Transaction(**entry) for entry in results]
 
-    def get_transaction(self, session: Session, id: int) -> Transaction:
+    def get_transaction(self, session: Session, id: int) -> Transaction:  # pragma: no cover
         """
         Get a single transaction by ID.
 
@@ -715,7 +715,7 @@ class Account(TastytradeJsonDataclass):
         session: ProductionSession,
         time_back: Optional[str] = None,
         start_time: Optional[datetime] = None
-    ) -> List[NetLiqOhlc]:  # pragma: no cover
+    ) -> List[NetLiqOhlc]:
         """
         Returns a list of account net liquidating value snapshots over the
         specified time period.
@@ -775,7 +775,7 @@ class Account(TastytradeJsonDataclass):
         self,
         session: ProductionSession,
         symbol: str
-    ) -> MarginRequirement:  # pragma: no cover
+    ) -> MarginRequirement:
         """
         Get the effective margin requirements for a given symbol.
 

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -412,7 +412,7 @@ class Option(TradeableTastytradeJsonDataclass):
         symbols: Optional[List[str]] = None,
         active: Optional[bool] = None,
         with_expired: Optional[bool] = None
-    ) -> List['Option']:
+    ) -> List['Option']:  # pragma: no cover
         """
         Returns a list of :class:`Option` objects from the given symbols.
 
@@ -1062,7 +1062,7 @@ def get_option_chain(
 def get_future_option_chain(
     session: ProductionSession,
     symbol: str
-) -> Dict[date, List[FutureOption]]:  # pragma: no cover
+) -> Dict[date, List[FutureOption]]:
     """
     Returns a mapping of expiration date to a list of futures options
     objects representing the options chain for the given symbol.

--- a/tastytrade/metrics.py
+++ b/tastytrade/metrics.py
@@ -93,7 +93,7 @@ class MarketMetricInfo(TastytradeJsonDataclass):
 def get_market_metrics(
     session: ProductionSession,
     symbols: List[str]
-) -> List[MarketMetricInfo]:  # pragma: no cover
+) -> List[MarketMetricInfo]:
     """
     Retrieves market metrics for the given symbols.
 
@@ -117,7 +117,7 @@ def get_market_metrics(
 def get_dividends(
     session: ProductionSession,
     symbol: str
-) -> List[DividendInfo]:  # pragma: no cover
+) -> List[DividendInfo]:
     """
     Retrieves dividend information for the given symbol.
 
@@ -142,7 +142,7 @@ def get_earnings(
     session: ProductionSession,
     symbol: str,
     start_date: date
-) -> List[EarningsInfo]:  # pragma: no cover
+) -> List[EarningsInfo]:
     """
     Retrieves earnings information for the given symbol.
 

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -113,7 +113,7 @@ class CertificationSession(Session):
         self.validate()
 
 
-class ProductionSession(Session):  # pragma: no cover
+class ProductionSession(Session):
     """
     Contains a local user login which can then be used to interact with the
     remote API.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from tastytrade import CertificationSession
+from tastytrade import ProductionSession
 
 
 @pytest.fixture(scope='session')
@@ -10,7 +10,10 @@ def session():
     username = os.environ.get('TT_USERNAME', None)
     password = os.environ.get('TT_PASSWORD', None)
 
-    session = CertificationSession(username, password)
+    assert username is not None
+    assert password is not None
+
+    session = ProductionSession(username, password)
     yield session
 
     session.destroy()

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1,7 +1,9 @@
-from tastytrade.instruments import (Cryptocurrency, Equity,
-                                    FutureOptionProduct, FutureProduct,
-                                    NestedOptionChain, Option, Warrant,
-                                    get_option_chain,
+from tastytrade.instruments import (Cryptocurrency, Equity, Future,
+                                    FutureOption, FutureOptionProduct,
+                                    FutureProduct, NestedOptionChain,
+                                    NestedFutureOptionChain, Option,
+                                    Warrant, get_option_chain,
+                                    get_future_option_chain,
                                     get_quantity_decimal_precisions)
 
 
@@ -25,6 +27,11 @@ def test_get_equity(session):
     Equity.get_equity(session, 'AAPL')
 
 
+def test_get_futures(session):
+    futures = Future.get_futures(session, product_codes=['ES'])
+    Future.get_future(session, futures[0].symbol)
+
+
 def test_get_future_product(session):
     FutureProduct.get_future_product(session, 'ZN')
 
@@ -45,8 +52,16 @@ def test_get_nested_option_chain(session):
     NestedOptionChain.get_chain(session, 'SPY')
 
 
+def test_get_nested_future_option_chain(session):
+    NestedFutureOptionChain.get_chain(session, 'ES')
+
+
 def test_get_warrants(session):
     Warrant.get_warrants(session)
+
+
+def test_get_warrant(session):
+    Warrant.get_warrant(session, 'NKLAW')
 
 
 def test_get_quantity_decimal_precisions(session):
@@ -55,9 +70,14 @@ def test_get_quantity_decimal_precisions(session):
 
 def test_get_option_chain(session):
     chain = get_option_chain(session, 'SPY')
-    symbols = []
     for options in chain.values():
-        symbols.extend([o.symbol for o in options])
+        Option.get_option(session, options[0].symbol)
         break
-    Option.get_option(session, symbols[0])
-    Option.get_options(session, symbols)
+
+
+def test_get_future_option_chain(session):
+    chain = get_future_option_chain(session, 'ES')
+    for options in chain.values():
+        FutureOption.get_future_option(session, options[0].symbol)
+        FutureOption.get_future_options(session, options[:4])
+        break

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -1,9 +1,8 @@
 from tastytrade.instruments import (Cryptocurrency, Equity, Future,
                                     FutureOption, FutureOptionProduct,
-                                    FutureProduct, NestedOptionChain,
-                                    NestedFutureOptionChain, Option,
-                                    Warrant, get_option_chain,
-                                    get_future_option_chain,
+                                    FutureProduct, NestedFutureOptionChain,
+                                    NestedOptionChain, Option, Warrant,
+                                    get_future_option_chain, get_option_chain,
                                     get_quantity_decimal_precisions)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,18 @@
-from tastytrade.metrics import get_risk_free_rate
+from datetime import date
+
+from tastytrade.metrics import get_dividends, get_earnings, get_market_metrics, get_risk_free_rate
+
+
+def test_get_dividends(session):
+    get_dividends(session, 'SPY')
+
+
+def test_get_earnings(session):
+    get_earnings(session, 'AAPL', date.today())
+
+
+def test_get_market_metrics(session):
+    get_market_metrics(session, ['SPY', 'AAPL'])
 
 
 def test_get_risk_free_rate(session):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,7 @@
 from datetime import date
 
-from tastytrade.metrics import get_dividends, get_earnings, get_market_metrics, get_risk_free_rate
+from tastytrade.metrics import (get_dividends, get_earnings,
+                                get_market_metrics, get_risk_free_rate)
 
 
 def test_get_dividends(session):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,6 @@
-import os
 from datetime import datetime, timedelta
 
-from tastytrade import CertificationSession, ProductionSession
+from tastytrade import CertificationSession
 from tastytrade.dxfeed import EventType
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,16 +1,28 @@
 import os
+from datetime import datetime, timedelta
 
-from tastytrade import CertificationSession
+from tastytrade import CertificationSession, ProductionSession
+from tastytrade.dxfeed import EventType
 
 
 def test_get_customer(session):
     assert session.get_customer() != {}
 
 
-def test_destroy():
-    # here we create a new session to avoid destroying the active one
-    username = os.environ.get('TT_USERNAME', None)
-    password = os.environ.get('TT_PASSWORD', None)
+def test_get_event(session):
+    session.get_event(EventType.QUOTE, ['SPY', 'AAPL'])
 
-    session = CertificationSession(username, password)
+
+def test_get_time_and_sale(session):
+    start_date = datetime.today() - timedelta(days=30)
+    session.get_time_and_sale(['SPY', 'AAPL'], start_date)
+
+
+def test_get_candle(session):
+    start_date = datetime.today() - timedelta(days=30)
+    session.get_candle(['SPY', 'AAPL'], '1d', start_date)
+
+
+def test_destroy():
+    session = CertificationSession('tastyware', ':4s-S9/9L&Q~C]@v')
     assert session.destroy()

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -1,22 +1,36 @@
-import pytest
-import pytest_asyncio
+from datetime import datetime, timedelta
 
-from tastytrade import Account, AccountStreamer
+import pytest
+
+from tastytrade import Account, AccountStreamer, DXLinkStreamer
+from tastytrade.dxfeed import EventType
 
 pytest_plugins = ('pytest_asyncio',)
 
 
-@pytest_asyncio.fixture
-async def streamer(session):
-    streamer = await AccountStreamer.create(session)
-    yield streamer
-    streamer.close()
+@pytest.mark.asyncio
+async def test_account_streamer(session):
+    async with AccountStreamer(session) as streamer:
+        await streamer.public_watchlists_subscribe()
+        await streamer.quote_alerts_subscribe()
+        await streamer.user_message_subscribe(session)
+        accounts = Account.get_accounts(session)
+        await streamer.account_subscribe(accounts)
 
 
 @pytest.mark.asyncio
-async def test_subscribe_all(session, streamer):
-    await streamer.public_watchlists_subscribe()
-    await streamer.quote_alerts_subscribe()
-    await streamer.user_message_subscribe(session)
-    accounts = Account.get_accounts(session)
-    await streamer.account_subscribe(accounts)
+async def test_dxlink_streamer(session):
+    message = "[{'eventType': 'Quote', 'eventSymbol': 'SPY', 'eventTime': 0, 'sequence': 0, 'timeNanoPart': 0, 'bidTime': 0, 'bidExchangeCode': 'Q', 'bidPrice': 450.5, 'bidSize': 796.0, 'askTime': 0, 'askExchangeCode': 'Q', 'askPrice': 450.55, 'askSize': 1100.0}, {'eventType': 'Quote', 'eventSymbol': 'AAPL', 'eventTime': 0, 'sequence': 0, 'timeNanoPart': 0, 'bidTime': 0, 'bidExchangeCode': 'Q', 'bidPrice': 190.39, 'bidSize': 1.0, 'askTime': 0, 'askExchangeCode': 'Q', 'askPrice': 190.44, 'askSize': 3.0}]"
+
+    async with DXLinkStreamer(session) as streamer:
+        subs = ['SPY', 'AAPL']
+        await streamer.subscribe(EventType.QUOTE, subs)
+        start_date = datetime.today() - timedelta(days=30)
+        await streamer.subscribe_candle(subs, '1d', start_date)
+        _ = await streamer.get_event(EventType.CANDLE)
+        async for _ in streamer.listen(EventType.QUOTE):
+            break
+        await streamer.unsubscribe_candle(subs[0], '1d')
+        await streamer.unsubscribe(EventType.QUOTE, subs[1])
+
+        streamer._map_message(message)

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -20,7 +20,7 @@ async def test_account_streamer(session):
 
 @pytest.mark.asyncio
 async def test_dxlink_streamer(session):
-    message = "[{'eventType': 'Quote', 'eventSymbol': 'SPY', 'eventTime': 0, 'sequence': 0, 'timeNanoPart': 0, 'bidTime': 0, 'bidExchangeCode': 'Q', 'bidPrice': 450.5, 'bidSize': 796.0, 'askTime': 0, 'askExchangeCode': 'Q', 'askPrice': 450.55, 'askSize': 1100.0}, {'eventType': 'Quote', 'eventSymbol': 'AAPL', 'eventTime': 0, 'sequence': 0, 'timeNanoPart': 0, 'bidTime': 0, 'bidExchangeCode': 'Q', 'bidPrice': 190.39, 'bidSize': 1.0, 'askTime': 0, 'askExchangeCode': 'Q', 'askPrice': 190.44, 'askSize': 3.0}]"
+    message = "[{'eventType': 'Quote', 'eventSymbol': 'SPY', 'eventTime': 0, 'sequence': 0, 'timeNanoPart': 0, 'bidTime': 0, 'bidExchangeCode': 'Q', 'bidPrice': 450.5, 'bidSize': 796.0, 'askTime': 0, 'askExchangeCode': 'Q', 'askPrice': 450.55, 'askSize': 1100.0}, {'eventType': 'Quote', 'eventSymbol': 'AAPL', 'eventTime': 0, 'sequence': 0, 'timeNanoPart': 0, 'bidTime': 0, 'bidExchangeCode': 'Q', 'bidPrice': 190.39, 'bidSize': 1.0, 'askTime': 0, 'askExchangeCode': 'Q', 'askPrice': 190.44, 'askSize': 3.0}]"  # noqa: E501
 
     async with DXLinkStreamer(session) as streamer:
         subs = ['SPY', 'AAPL']


### PR DESCRIPTION
## Description
Updates streamers to be compatible with async context managers (old format still available).
Added this to docs as well.
Updated tests to use production session, credentials must be provided by each user in their own local fork.

## Pre-merge checklist
- [ ] Passing tests
- [ ] New tests added (if applicable)
