### PR TITLE
Update orders.rst

### DIFF
--- a/docs/orders.rst
+++ b/docs/orders.rst
@@ -19,7 +19,7 @@ Placing an order
        time_in_force=OrderTimeInForce.DAY,
        order_type=OrderType.LIMIT,
        legs=[leg],  # you can have multiple legs in an order
-       price=Decimal('50'),  # limit price, here $50 for 5 shares = $10/share
+       price=Decimal('10'),  # limit price, $10/share for a total value for $50
        price_effect=PriceEffect.DEBIT
    )
    response = account.place_order(session, order, dry_run=True)  # a test order


### PR DESCRIPTION
## Description
When I run the given example locally, i find that $50 is used as the limit price per share not in total for a buying power decrease for $250, correcting the message the comment conveys in this pull request

## Related issue(s)
Fixes ...

## Pre-merge checklist
- [ ] Passing tests LOCALLY
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
