### PR TITLE
add utility functions for options/futures options exp dates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'tastytrade'
 copyright = '2023, Graeme Holliday'
 author = 'Graeme Holliday'
-release = '6.5'
+release = '6.6'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flake8==5.0.4
 isort==5.11.5
 types-requests==2.31.0.1
 websockets==11.0.3
+pandas_market_calendars==4.3.3
 pydantic==1.10.11
 pytest==7.4.0
 pytest_cov==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='tastytrade',
-    version='6.5',
+    version='6.6',
     description='An unofficial SDK for Tastytrade!',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/x-rst',
@@ -18,7 +18,8 @@ setup(
     install_requires=[
         'requests<3',
         'websockets>=11.0.3',
-        'pydantic<2'
+        'pydantic<2',
+        'pandas_market_calendars>=4.3.3'
     ],
     packages=find_packages(exclude=['ez_setup', 'tests*']),
     include_package_data=True

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 API_URL = 'https://api.tastyworks.com'
 CERT_URL = 'https://api.cert.tastyworks.com'
-VERSION = '6.5'
+VERSION = '6.6'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -1002,7 +1002,7 @@ class Account(TastytradeJsonDataclass):
         self,
         session: Session,
         order: NewOrder,
-        dry_run=True
+        dry_run: bool = True
     ) -> PlacedOrderResponse:
         """
         Place the given order.
@@ -1032,7 +1032,7 @@ class Account(TastytradeJsonDataclass):
         self,
         session: Session,
         order: NewComplexOrder,
-        dry_run=True
+        dry_run: bool = True
     ) -> PlacedOrderResponse:
         """
         Place the given order.

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -496,7 +496,7 @@ class Option(TradeableTastytradeJsonDataclass):
         if match is None:
             return ''
         symbol = match.group(1)[:6].ljust(6)
-        exp = datetime.strptime(match.group(2), '%y%m%d').strftime('%Y%m%d')
+        exp = match.group(2)
         option_type = match.group(3)
         strike = match.group(4).zfill(5)
         if match.group(6) is not None:

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -346,7 +346,7 @@ class PlacedOrderResponse(TastytradeJsonDataclass):
     Dataclass grouping together information about a placed order.
     """
     buying_power_effect: BuyingPowerEffect
-    fee_calculation: FeeCalculation
+    fee_calculation: Optional[FeeCalculation] = None
     order: Optional[PlacedOrder] = None
     complex_order: Optional[PlacedComplexOrder] = None
     warnings: Optional[List[Message]] = None

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -84,5 +84,5 @@ def test_get_future_option_chain(session):
 
 def test_streamer_symbol_to_occ():
     dxf = '.SPY240324P480.5'
-    occ = 'SPY   20240324P00480500'
+    occ = 'SPY   240324P00480500'
     assert Option.streamer_symbol_to_occ(dxf) == occ

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,108 @@
+from datetime import date
+
+from tastytrade.utils import (get_future_fx_monthly, get_future_grain_monthly,
+                              get_future_metal_monthly,
+                              get_future_treasury_monthly, get_tasty_monthly,
+                              get_third_friday)
+
+
+def test_get_third_friday():
+    assert get_third_friday(date(2024, 3, 2)) == date(2024, 3, 15)
+
+
+def test_get_tasty_monthly():
+    delta = (get_tasty_monthly() - date.today()).days
+    assert abs(45 - delta) <= 17
+
+
+def test_get_future_fx_monthly():
+    exps = [
+        date(2024, 2, 9),
+        date(2024, 3, 8),
+        date(2024, 4, 5),
+        date(2024, 5, 3),
+        date(2024, 6, 7),
+        date(2024, 7, 5),
+        date(2024, 8, 9),
+        date(2024, 9, 6),
+        date(2024, 10, 4),
+        date(2024, 11, 8),
+        date(2024, 12, 6),
+        date(2025, 1, 3),
+        date(2025, 2, 7),
+        date(2025, 3, 7),
+        date(2025, 6, 6),
+        date(2025, 9, 5),
+        date(2025, 12, 5)
+    ]
+    for exp in exps:
+        assert get_future_fx_monthly(exp) == exp
+
+
+def test_get_future_treasury_monthly():
+    exps = [
+        date(2024, 2, 23),
+        date(2024, 3, 22),
+        date(2024, 4, 26),
+        date(2024, 5, 24),
+        date(2024, 6, 21),
+        date(2024, 8, 23)
+    ]
+    for exp in exps:
+        assert get_future_treasury_monthly(exp) == exp
+
+
+def test_get_future_grain_monthly():
+    exps = [
+        date(2024, 2, 23),
+        date(2024, 3, 22),
+        date(2024, 4, 26),
+        date(2024, 5, 24),
+        date(2024, 6, 21),
+        date(2024, 8, 23),
+        date(2024, 11, 22),
+        date(2025, 2, 21),
+        date(2025, 4, 25),
+        date(2025, 6, 20),
+        date(2025, 11, 21),
+        date(2026, 6, 26),
+        date(2026, 11, 20)
+    ]
+    for exp in exps:
+        assert get_future_grain_monthly(exp) == exp
+
+
+def test_get_future_metal_monthly():
+    exps = [
+        date(2024, 2, 26),
+        date(2024, 3, 25),
+        date(2024, 4, 25),
+        date(2024, 5, 28),
+        date(2024, 6, 25),
+        date(2024, 7, 25),
+        date(2024, 8, 27),
+        date(2024, 9, 25),
+        date(2024, 10, 28),
+        date(2024, 11, 25),
+        date(2024, 12, 26),
+        date(2025, 1, 28),
+        date(2025, 2, 25),
+        date(2025, 3, 26),
+        date(2025, 4, 24),
+        date(2025, 5, 27),
+        date(2025, 6, 25),
+        date(2025, 7, 28),
+        date(2025, 8, 26),
+        date(2025, 9, 25),
+        date(2025, 11, 24),
+        date(2026, 5, 26),
+        date(2026, 11, 24),
+        date(2027, 5, 25),
+        date(2027, 11, 23),
+        date(2028, 5, 25),
+        date(2028, 11, 27),
+        date(2029, 5, 24),
+        date(2029, 11, 27)
+    ]
+    for exp in exps:
+        assert get_future_metal_monthly(exp) == exp


### PR DESCRIPTION
## Description
Adds new utility functions to calculate monthly expiration dates for options and options on futures.
- `get_third_friday`: Gets the third Friday of the given date, which corresponds to the monthly for that date.
- `get_tasty_monthly`: Returns the monthly expiration closest to 45 days to expiration (for the Tastytraders out there!)
- `get_future_fx_monthly`: Returns the monthly expiration for FX futures options for the given month.
- `get_future_treasury_monthly`: Returns the monthly expiration for treasury futures options for the given month.
- `get_future_metal_monthly`: Returns the monthly expiration for metals futures options for the given month.
- `get_future_grain_monthly`: Returns the monthly expiration for grain futures options for the given month.

## Pre-merge checklist
- [x] Passing tests LOCALLY
- [x] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
