### PR TITLE
Fixed complex orders + error messages

### DIFF
--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -283,9 +283,9 @@ class PlacedOrder(TastytradeJsonDataclass):
     user_id: Optional[str] = None
     username: Optional[str] = None
     terminal_at: Optional[datetime] = None
-    complex_order_id: Optional[str] = None
+    complex_order_id: Optional[str|int] = None
     complex_order_tag: Optional[str] = None
-    preflight_id: Optional[str] = None
+    preflight_id: Optional[str|int] = None
     order_rule: Optional[OrderRule] = None
 
 

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -296,7 +296,7 @@ class PlacedComplexOrder(TastytradeJsonDataclass):
     account_number: str
     type: str
     orders: List[PlacedOrder]
-    id: Optional[str] = None
+    id: Optional[str|int] = None
     trigger_order: Optional[PlacedOrder] = None
     terminal_at: Optional[str] = None
     ratio_price_threshold: Optional[Decimal] = None

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from tastytrade import VERSION
 from tastytrade.utils import TastytradeJsonDataclass
@@ -283,9 +283,9 @@ class PlacedOrder(TastytradeJsonDataclass):
     user_id: Optional[str] = None
     username: Optional[str] = None
     terminal_at: Optional[datetime] = None
-    complex_order_id: Optional[str|int] = None
+    complex_order_id: Optional[Union[str, int]] = None
     complex_order_tag: Optional[str] = None
-    preflight_id: Optional[str|int] = None
+    preflight_id: Optional[Union[str, int]] = None
     order_rule: Optional[OrderRule] = None
 
 
@@ -296,7 +296,7 @@ class PlacedComplexOrder(TastytradeJsonDataclass):
     account_number: str
     type: str
     orders: List[PlacedOrder]
-    id: Optional[str|int] = None
+    id: Optional[Union[str, int]] = None
     trigger_order: Optional[PlacedOrder] = None
     terminal_at: Optional[str] = None
     ratio_price_threshold: Optional[Decimal] = None

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -218,6 +218,9 @@ def validate_response(response: Response) -> None:
         errors = content.get('errors')
         if errors is not None:
             for error in errors:
-                error_message += f"\n{error['code']}: {error['message']}"
+                if "code" in error:
+                    error_message += f"\n{error['code']}: {error['message']}"
+                else:
+                    error_message += f"\n{error['domain']}: {error['reason']}"
 
         raise TastytradeError(error_message)


### PR DESCRIPTION
## Description
- Example for complex orders is not working because the preflight_id and complex_order_id are returned as int
- For missing stop_triggers the error messages do not contain "code"

