### PR TITLE
add new fields to strike (fix #138)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'tastytrade'
 copyright = '2023, Graeme Holliday'
 author = 'Graeme Holliday'
-release = '7.0'
+release = '7.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='tastytrade',
-    version='7.0',
+    version='7.1',
     description='An unofficial SDK for Tastytrade!',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/x-rst',

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 API_URL = 'https://api.tastyworks.com'
 CERT_URL = 'https://api.cert.tastyworks.com'
-VERSION = '7.0'
+VERSION = '7.1'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -87,6 +87,8 @@ class Strike(TastytradeJsonDataclass):
     strike_price: Decimal
     call: str
     put: str
+    call_streamer_symbol: str
+    put_streamer_symbol: str
 
 
 class TickSize(TastytradeJsonDataclass):


### PR DESCRIPTION
## Description
Adds new fields to Strike object (from nested future/normal option chains) to handle incoming streamer symbols.

## Related issue(s)
Fixes #138

## Pre-merge checklist
- [x] Passing tests LOCALLY
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
