### PR TITLE
Added DXLinkStreamer.get_event_nowait()

### DIFF
--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -179,7 +179,6 @@ class MarginReportEntry(TastytradeJsonDataclass):
     margin_calculation_type: str
     margin_requirement: Decimal
     margin_requirement_effect: PriceEffect
-    point_of_no_return_percent: Decimal
     expected_price_range_up_percent: Optional[Decimal] = None
     expected_price_range_down_percent: Optional[Decimal] = None
     groups: Optional[List[Dict[str, Any]]] = None
@@ -187,6 +186,7 @@ class MarginReportEntry(TastytradeJsonDataclass):
     initial_requirement_effect: Optional[PriceEffect] = None
     maintenance_requirement: Optional[Decimal] = None
     maintenance_requirement_effect: Optional[PriceEffect] = None
+    point_of_no_return_percent: Optional[Decimal] = None
     price_increase_percent: Optional[Decimal] = None
     price_decrease_percent: Optional[Decimal] = None
     underlying_symbol: Optional[str] = None

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -174,23 +174,23 @@ class MarginReportEntry(TastytradeJsonDataclass):
     """
     description: str
     code: str
-    underlying_symbol: str
-    underlying_type: str
+    buying_power: Decimal
+    buying_power_effect: PriceEffect
     margin_calculation_type: str
     margin_requirement: Decimal
     margin_requirement_effect: PriceEffect
-    maintenance_requirement: Decimal
-    maintenance_requirement_effect: PriceEffect
-    buying_power: Decimal
-    buying_power_effect: PriceEffect
-    groups: List[Dict[str, Any]]
-    price_increase_percent: Decimal
-    price_decrease_percent: Decimal
+    point_of_no_return_percent: Decimal
     expected_price_range_up_percent: Optional[Decimal] = None
     expected_price_range_down_percent: Optional[Decimal] = None
-    point_of_no_return_percent: Optional[Decimal] = None
+    groups: Optional[List[Dict[str, Any]]] = None
     initial_requirement: Optional[Decimal] = None
     initial_requirement_effect: Optional[PriceEffect] = None
+    maintenance_requirement: Optional[Decimal] = None
+    maintenance_requirement_effect: Optional[PriceEffect] = None
+    price_increase_percent: Optional[Decimal] = None
+    price_decrease_percent: Optional[Decimal] = None
+    underlying_symbol: Optional[str] = None
+    underlying_type: Optional[str] = None
 
 
 class MarginReport(TastytradeJsonDataclass):

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -392,6 +392,18 @@ class DXLinkStreamer:
         while True:
             yield await self._queues[event_type].get()
 
+    def get_event_nowait(self, event_type: EventType) -> Optional[Event]:
+        """
+        Using the existing subscriptions, pulls an event of the given type and
+        returns it. if the queue is empty None is returned.
+
+        :param event_type: the type of event to get
+        """
+        if not self._queues[event_type].empty():
+            return self._queues[event_type].get_nowait()
+        else:
+            return None
+
     async def get_event(self, event_type: EventType) -> Event:
         """
         Using the existing subscription, pulls an event of the given type and

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -31,11 +31,15 @@ async def test_dxlink_streamer(session):
         await streamer.unsubscribe_candle(subs[0], '1d')
         await streamer.unsubscribe(EventType.QUOTE, subs[1])
 
-        subs = ['QQQ', 'BA']
-        await streamer.subscribe(EventType.QUOTE, subs)
-        start_date = datetime.today() + timedelta(days=30)
-        await streamer.subscribe_candle(subs, '1d', start_date)
-        assert streamer.get_event_nowait(EventType.CANDLE) is None
-        assert streamer.listen(EventType.QUOTE) is not None
-        await streamer.unsubscribe_candle(subs[0], '1d')
-        await streamer.unsubscribe(EventType.QUOTE, subs[1])
+
+@pytest.mark.asyncio
+async def test_dxlink_streamer_nowait(session):
+    async with DXLinkStreamer(session) as streamer:
+        subs_not_none = ['SPY']
+        subs_none = ['QQQQ']
+        await streamer.subscribe(EventType.TRADE, subs_not_none)
+        await streamer.subscribe(EventType.QUOTE, subs_none)
+        assert streamer.get_event_nowait(EventType.TRADE) is not None
+        assert streamer.get_event_nowait(EventType.QUOTE) is None
+        await streamer.unsubscribe(EventType.TRADE, subs_not_none)
+        await streamer.unsubscribe(EventType.QUOTE, subs_none)

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -30,3 +30,12 @@ async def test_dxlink_streamer(session):
             break
         await streamer.unsubscribe_candle(subs[0], '1d')
         await streamer.unsubscribe(EventType.QUOTE, subs[1])
+
+        subs = ['QQQ', 'BA']
+        await streamer.subscribe(EventType.QUOTE, subs)
+        start_date = datetime.today() + timedelta(days=30)
+        await streamer.subscribe_candle(subs, '1d', start_date)
+        assert streamer.get_event_nowait(EventType.CANDLE) is None
+        assert streamer.listen(EventType.QUOTE) is not None
+        await streamer.unsubscribe_candle(subs[0], '1d')
+        await streamer.unsubscribe(EventType.QUOTE, subs[1])


### PR DESCRIPTION
## Description

## Related issue(s)
Fixes #148 

## Pre-merge checklist
- [ ] Passing tests LOCALLY
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
