### PR TITLE
fix small candle bug, use accept and content type headers in sessions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'tastytrade'
 copyright = '2024, Graeme Holliday'
 author = 'Graeme Holliday'
-release = '7.6'
+release = '7.7'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ isort==5.13.2
 types-requests==2.31.0.20240406
 types-pytz==2024.1.0.20240417
 websockets==12.0
-pandas_market_calendars==4.4.0
+pandas_market_calendars==4.3.3
 pydantic==2.7.1
 pytest==8.2.1
 pytest_cov==5.0.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='tastytrade',
-    version='7.6',
+    version='7.7',
     description='An unofficial SDK for Tastytrade!',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/x-rst',

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 API_URL = 'https://api.tastyworks.com'
 CERT_URL = 'https://api.cert.tastyworks.com'
-VERSION = '7.6'
+VERSION = '7.7'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -1021,9 +1021,6 @@ class Account(TastytradeJsonDataclass):
         url = f'{session.base_url}/accounts/{self.account_number}/orders'
         if dry_run:
             url += '/dry-run'
-        headers = session.headers
-        # required because we're passing the JSON as a string
-        headers['Content-Type'] = 'application/json'
         json = order.model_dump_json(exclude_none=True, by_alias=True)
 
         response = requests.post(url, headers=session.headers, data=json)
@@ -1054,9 +1051,6 @@ class Account(TastytradeJsonDataclass):
                '/complex-orders')
         if dry_run:
             url += '/dry-run'
-        headers = session.headers
-        # required because we're passing the JSON as a string
-        headers['Content-Type'] = 'application/json'
         json = order.model_dump_json(exclude_none=True, by_alias=True)
 
         response = requests.post(url, headers=session.headers, data=json)
@@ -1082,13 +1076,10 @@ class Account(TastytradeJsonDataclass):
 
         :return: a :class:`PlacedOrder` object for the modified order.
         """
-        headers = session.headers
-        # required because we're passing the JSON as a string
-        headers['Content-Type'] = 'application/json'
         response = requests.put(
             (f'{session.base_url}/accounts/{self.account_number}/orders'
              f'/{old_order_id}'),
-            headers=headers,
+            headers=session.headers,
             data=new_order.model_dump_json(
                 exclude={'legs'},
                 exclude_none=True,

--- a/tastytrade/dxfeed/event.py
+++ b/tastytrade/dxfeed/event.py
@@ -30,7 +30,7 @@ class EventType(str, Enum):
 class Event(BaseModel):
     @validator('*', pre=True)
     def change_nan_to_none(cls, v):
-        if v == 'NaN' or v == 'Infinity':
+        if v == 'NaN' or v == 'Infinity' or v == '-Infinity':
             return None
         return v
 

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -112,7 +112,11 @@ class CertificationSession(Session):
         self.remember_token: Optional[str] = \
             json['data']['remember-token'] if remember_me else None
         #: The headers to use for API requests
-        self.headers: Dict[str, str] = {'Authorization': self.session_token}
+        self.headers: Dict[str, str] = {
+            'Accept': 'application/json',
+            'Authorization': self.session_token,
+            'Content-Type': 'application/json'
+        }
         self.validate()
 
         # Pull streamer tokens and urls
@@ -167,7 +171,11 @@ class ProductionSession(Session):
         #: The base url to use for API requests
         self.base_url: str = API_URL
         #: The headers to use for API requests
-        self.headers: Dict[str, str] = {'User-Agent': UserAgent().random}
+        self.headers: Dict[str, str] = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'User-Agent': UserAgent().random
+        }
 
         if two_factor_authentication is not None:
             headers = {

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -26,7 +26,7 @@ from tastytrade.watchlists import Watchlist
 CERT_STREAMER_URL = 'wss://streamer.cert.tastyworks.com'
 STREAMER_URL = 'wss://streamer.tastyworks.com'
 
-DXLINK_VERSION = '0.1-js/0.40.4-WB2'
+DXLINK_VERSION = '0.1-js/1.0.0-beta.4'
 
 
 class QuoteAlert(TastytradeJsonDataclass):


### PR DESCRIPTION
## Description
Fixes a bug with candles when value is "-Infinity".

## Pre-merge checklist
- [ ] Passing tests LOCALLY
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
