### PR TITLE
add order chains, add is_market_open_on util

### DIFF
--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -3,6 +3,7 @@ import logging
 API_URL = "https://api.tastyworks.com"
 BACKTEST_URL = "https://backtester.vast.tastyworks.com"
 CERT_URL = "https://api.cert.tastyworks.com"
+VAST_URL = "https://vast.tastyworks.com"
 VERSION = "9.0"
 
 logger = logging.getLogger(__name__)

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -528,11 +528,11 @@ class OrderChain(TastytradeJsonDataclass):
     """
 
     id: int
-    updated_at: datetime
-    created_at: datetime
     account_number: str
     description: str
     underlying_symbol: str
     computed_data: ComputedData
-    lite_nodes_sizes: int
     lite_nodes: List[OrderChainNode]
+    lite_nodes_sizes: Optional[int] = None
+    updated_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -41,6 +41,19 @@ def today_in_new_york() -> date:
     return now_in_new_york().date()
 
 
+def is_market_open_on(day: date = today_in_new_york()) -> bool:
+    """
+    Returns whether the market was/is/will be open at ANY point
+    during the given day.
+
+    :param day: date to check
+
+    :return: whether the market opens on given day
+    """
+    date_range = NYSE.valid_days(day, day)
+    return len(date_range) != 0
+
+
 def get_third_friday(day: date = today_in_new_york()) -> date:
     """
     Gets the monthly expiration associated with the month of the given date,

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from decimal import Decimal
 from time import sleep
 
@@ -146,6 +147,20 @@ async def test_get_complex_order_history_async(session, account):
 
 async def test_get_live_orders_async(session, account):
     await account.a_get_live_orders(session)
+
+
+def test_get_order_chains(session, account):
+    start_time = datetime(2024, 1, 1, 0, 0, 0)
+    end_time = datetime.now()
+    account.get_order_chains(session, "F", start_time=start_time, end_time=end_time)
+
+
+async def test_get_order_chains_async(session, account):
+    start_time = datetime(2024, 1, 1, 0, 0, 0)
+    end_time = datetime.now()
+    await account.a_get_order_chains(
+        session, "F", start_time=start_time, end_time=end_time
+    )
 
 
 @fixture(scope="module")

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -27,4 +27,5 @@ async def test_dxlink_streamer(session):
         async for _ in streamer.listen(Quote):
             break
         await streamer.unsubscribe_candle(subs[0], "1d")
-        await streamer.unsubscribe(Quote, subs)
+        await streamer.unsubscribe(Quote, [subs[0]])
+        await streamer.unsubscribe_all(Quote)


### PR DESCRIPTION
## Description
Adds a way to fetch order chains manually (previously only available in account streamer)
Adds a utility function, `is_market_open_on` to check market calendar for a given date.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Code implemented for both sync and async
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
