### PR TITLE
fix dry run bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async with DXLinkStreamer(session) as streamer:
 ```
 
 ```python
->>> [Quote(eventSymbol='SPY', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='Q', bidPrice=411.58, bidSize=400.0, askTime=0, askExchangeCode='Q', askPrice=411.6, askSize=1313.0), Quote(eventSymbol='SPX', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='\x00', bidPrice=4122.49, bidSize='NaN', askTime=0, askExchangeCode='\x00', askPrice=4123.65, askSize='NaN')]
+>>> Quote(eventSymbol='SPY', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='Q', bidPrice=411.58, bidSize=400.0, askTime=0, askExchangeCode='Q', askPrice=411.6, askSize=1313.0)
 ```
 
 Note that this is asynchronous code, so you can't run it as is unless you're using a Jupyter notebook or something similar.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "tastytrade"
 copyright = "2024, Graeme Holliday"
 author = "Graeme Holliday"
-release = "9.0"
+release = "9.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/data-streamer.rst
+++ b/docs/data-streamer.rst
@@ -25,7 +25,7 @@ Once you've created the streamer, you can subscribe/unsubscribe to events, like 
 .. code-block:: python
 
    from tastytrade.dxfeed import Quote
-   subs_list = ['SPY', 'SPX']
+   subs_list = ['SPY']  # you can add more symbols here!
 
    async with DXLinkStreamer(session) as streamer:
        await streamer.subscribe(Quote, subs_list)
@@ -36,7 +36,7 @@ Once you've created the streamer, you can subscribe/unsubscribe to events, like 
                break
        print(quotes)
 
->>> {'SPY': Quote(eventSymbol='SPY', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='Q', bidPrice=411.58, bidSize=400.0, askTime=0, askExchangeCode='Q', askPrice=411.6, askSize=1313.0), 'SPX': Quote(eventSymbol='SPX', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='\x00', bidPrice=4122.49, bidSize='NaN', askTime=0, askExchangeCode='\x00', askPrice=4123.65, askSize='NaN')}
+>>> [{'SPY': Quote(eventSymbol='SPY', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='Q', bidPrice=411.58, bidSize=400.0, askTime=0, askExchangeCode='Q', askPrice=411.6, askSize=1313.0), 'SPX': Quote(eventSymbol='SPX', eventTime=0, sequence=0, timeNanoPart=0, bidTime=0, bidExchangeCode='\x00', bidPrice=4122.49, bidSize='NaN', askTime=0, askExchangeCode='\x00', askPrice=4123.65, askSize='NaN')}]
 
 Note that these are ``asyncio`` calls, so you'll need to run this code asynchronously. Here's an example:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tastytrade"
-version = "9.0"
+version = "9.1"
 description = "An unofficial, sync/async SDK for Tastytrade!"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,7 +4,7 @@ API_URL = "https://api.tastyworks.com"
 BACKTEST_URL = "https://backtester.vast.tastyworks.com"
 CERT_URL = "https://api.cert.tastyworks.com"
 VAST_URL = "https://vast.tastyworks.com"
-VERSION = "9.0"
+VERSION = "9.1"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -281,7 +281,6 @@ class PlacedOrder(TastytradeJsonDataclass):
     """
 
     account_number: str
-    id: int
     time_in_force: OrderTimeInForce
     order_type: OrderType
     underlying_symbol: str
@@ -292,6 +291,8 @@ class PlacedOrder(TastytradeJsonDataclass):
     edited: bool
     updated_at: datetime
     legs: List[Leg]
+    #: the ID of the order; test orders placed with dry_run don't have an ID
+    id: int = -1
     size: Optional[Decimal] = None
     price: Optional[Decimal] = None
     gtc_date: Optional[date] = None
@@ -328,9 +329,10 @@ class PlacedComplexOrder(TastytradeJsonDataclass):
     """
 
     account_number: str
-    id: int
     type: str
     orders: List[PlacedOrder]
+    #: the ID of the order; test orders placed with dry_run don't have an ID
+    id: int = -1
     trigger_order: Optional[PlacedOrder] = None
     terminal_at: Optional[str] = None
     ratio_price_threshold: Optional[Decimal] = None

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -205,7 +205,7 @@ class AlertStreamer:
         self = cls(session)
         return await self.__aenter__()
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, *exc):
         await self.close()
 
     async def close(self):
@@ -381,7 +381,7 @@ class DXLinkStreamer:
         self = cls(session, ssl_context=ssl_context)
         return await self.__aenter__()
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, *exc):
         await self.close()
 
     async def close(self):

--- a/uv.lock
+++ b/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "tastytrade"
-version = "9.0"
+version = "9.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Description
Fixes a bug when placing orders with `dry_run=True` causing an exception to be raised.

## Related issue(s)
Fixes #174

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Code implemented for both sync and async
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
