### PR TITLE
candles default to 0, add event flags

### DIFF
--- a/tastytrade/dxfeed/candle.py
+++ b/tastytrade/dxfeed/candle.py
@@ -1,18 +1,20 @@
 from decimal import Decimal
 from typing import Optional
 
-from .event import Event
+from pydantic import Field, computed_field
+
+from .event import IndexedEvent
+
+ZERO = Decimal(0)
 
 
-class Candle(Event):
+class Candle(IndexedEvent):
     """
     A Candle event with open, high, low, close prices and other information
     for a specific period. Candles are build with a specified period using a
     specified price type with data taken from a specified exchange.
     """
 
-    #: transactional event flags
-    event_flags: int
     #: unique per-symbol index of this candle event
     index: int
     #: timestamp of the candle in milliseconds
@@ -21,14 +23,6 @@ class Candle(Event):
     sequence: int
     #: total number of events in the candle
     count: int
-    #: the first (open) price of the candle
-    open: Decimal
-    #: the maximal (high) price of the candle
-    high: Decimal
-    #: the minimal (low) price of the candle
-    low: Decimal
-    #: the last (close) price of the candle
-    close: Decimal
     #: the total volume of the candle
     volume: Optional[Decimal] = None
     #: volume-weighted average price
@@ -41,3 +35,40 @@ class Candle(Event):
     imp_volatility: Optional[Decimal] = None
     #: open interest in the candle
     open_interest: Optional[int] = None
+    # these fields will not show up in serialization
+    raw_open: Optional[Decimal] = Field(validation_alias="open", exclude=True)
+    raw_high: Optional[Decimal] = Field(validation_alias="high", exclude=True)
+    raw_low: Optional[Decimal] = Field(validation_alias="low", exclude=True)
+    raw_close: Optional[Decimal] = Field(validation_alias="close", exclude=True)
+
+    @computed_field
+    @property
+    def open(self) -> Decimal:
+        """
+        the first (open) price of the candle
+        """
+        return self.raw_open or ZERO
+
+    @computed_field
+    @property
+    def high(self) -> Decimal:
+        """
+        the maximal (high) price of the candle
+        """
+        return self.raw_high or ZERO
+
+    @computed_field
+    @property
+    def low(self) -> Decimal:
+        """
+        the minimal (low) price of the candle
+        """
+        return self.raw_low or ZERO
+
+    @computed_field
+    @property
+    def close(self) -> Decimal:
+        """
+        the last (close) price of the candle
+        """
+        return self.raw_close or ZERO

--- a/tastytrade/dxfeed/greeks.py
+++ b/tastytrade/dxfeed/greeks.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
 
-from .event import Event
+from .event import IndexedEvent
 
 
-class Greeks(Event):
+class Greeks(IndexedEvent):
     """
     Greek ratios, or simply Greeks, are differential values that show how the
     price of an option depends on other market parameters: on the price of the
@@ -13,8 +13,6 @@ class Greeks(Event):
     portfolio has a risky sensitivity in this parameter.
     """
 
-    #: transactional event flags
-    event_flags: int
     #: unique per-symbol index of this event
     index: int
     #: timestamp of this event in milliseconds

--- a/tastytrade/dxfeed/theoprice.py
+++ b/tastytrade/dxfeed/theoprice.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
 
-from .event import Event
+from .event import IndexedEvent
 
 
-class TheoPrice(Event):
+class TheoPrice(IndexedEvent):
     """
     Theo price is a snapshot of the theoretical option price computation that
     is periodically performed by dxPrice model-free computation. dxFeed does
@@ -12,8 +12,6 @@ class TheoPrice(Event):
     this event.
     """
 
-    #: transactional event flags
-    event_flags: int
     #: unique per-symbol index of this event
     index: int
     #: timestamp of this event in milliseconds

--- a/tastytrade/dxfeed/timeandsale.py
+++ b/tastytrade/dxfeed/timeandsale.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
 
-from .event import Event
+from .event import IndexedEvent
 
 
-class TimeAndSale(Event):
+class TimeAndSale(IndexedEvent):
     """
     TimeAndSale event represents a trade or other market event with a price,
     like market open/close price. TimeAndSale events are intended to provide
@@ -13,8 +13,6 @@ class TimeAndSale(Event):
     correction/cancellation processing.
     """
 
-    #: transactional event flags
-    event_flags: int
     #: unique per-symbol index of this time and sale event
     index: int
     #: timestamp of the original event

--- a/tastytrade/dxfeed/underlying.py
+++ b/tastytrade/dxfeed/underlying.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
 
-from .event import Event
+from .event import IndexedEvent
 
 
-class Underlying(Event):
+class Underlying(IndexedEvent):
     """
     Underlying event is a snapshot of computed values that are available for
     an option underlying symbol based on the option prices on the market. It
@@ -11,8 +11,6 @@ class Underlying(Event):
     corresponding values on the market at any given moment of time.
     """
 
-    #: transactional event flags
-    event_flags: int
     #: unique per-symbol index of this event
     index: int
     #: timestamp of this event in milliseconds


### PR DESCRIPTION
## Description
This PR partially reverts changes in v9.3 which made `tastytrade.dxfeed.Candle` events require OHLC fields.
Now, these fields are "optional", but if not present, will default to zero. OHLC fields are now computed properties.
This is because, as identified in #183, candles without OHLC data can still be useful in some circumstances by providing the `event_flags` which contains info about snapshot series begin, end, and occassionally other things.
As a result, the `tastytrade.dxfeed.IndexedEvent` class with extends the base `Event` was also added, which contains utility properties which are just `bool`s computed from the bitwise info contained in `event_flags`.

## Related issue(s)
Fixes #183

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
