### PR TITLE
add streamer reconnection callbacks

### DIFF
--- a/docs/account-streamer.rst
+++ b/docs/account-streamer.rst
@@ -57,3 +57,5 @@ This callback can then be used when creating the streamer:
 
     async with AlertStreamer(session, reconnect_fn=callback, reconnect_args=(arg1, arg2)) as streamer:
         # ...
+
+The reconnection uses `websockets`' exponential backoff algorithm, which can be configured through environment variables `here <https://websockets.readthedocs.io/en/14.1/reference/variables.html>`_.

--- a/docs/account-streamer.rst
+++ b/docs/account-streamer.rst
@@ -1,6 +1,9 @@
 Account Streamer
 ================
 
+Basic usage
+-----------
+
 The account streamer is used to track account-level updates, such as order fills, watchlist updates and quote alerts.
 Typically, you'll want a separate task running for the account streamer, which can then notify your application about important events.
 
@@ -35,3 +38,22 @@ Probably the most important information the account streamer handles is order fi
 
         async for order in streamer.listen(PlacedOrder):
             print(order)
+
+Retry callback
+--------------
+
+The account streamer has a special "callback" function which can be used to execute arbitrary code whenever the websocket reconnects. This is useful for re-subscribing to whatever alerts you wanted to subscribe to initially (in fact, you can probably use the same function/code you use when initializing the connection).
+The callback function should look something like this:
+
+.. code-block:: python
+
+    async def callback(streamer: AlertStreamer, arg1, arg2):
+        await streamer.subscribe_quote_alerts()
+
+The requirements are that the first parameter be the `AlertStreamer` instance, and the function should be asynchronous. Other than that, you have the flexibility to decide what arguments you want to use.
+This callback can then be used when creating the streamer:
+
+.. code-block:: python
+
+    async with AlertStreamer(session, reconnect_fn=callback, reconnect_args=(arg1, arg2)) as streamer:
+        # ...

--- a/docs/data-streamer.rst
+++ b/docs/data-streamer.rst
@@ -146,3 +146,22 @@ Now, we can access the quotes and greeks at any time, and they'll be up-to-date 
    print(live_prices.quotes[symbol], live_prices.greeks[symbol])
 
 >>> Quote(eventSymbol='.SPY230721C387', eventTime=0, sequence=0, timeNanoPart=0, bidTime=1689365699000, bidExchangeCode='X', bidPrice=62.01, bidSize=50.0, askTime=1689365699000, askExchangeCode='X', askPrice=62.83, askSize=50.0) Greeks(eventSymbol='.SPY230721C387', eventTime=0, eventFlags=0, index=7255910303911641088, time=1689398266363, sequence=0, price=62.6049270064687, volatility=0.536152815048564, delta=0.971506591907638, gamma=0.001814464566110275, theta=-0.1440768557397271, rho=0.0831882577866199, vega=0.0436861878838861)
+
+Retry callback
+--------------
+
+The data streamer has a special "callback" function which can be used to execute arbitrary code whenever the websocket reconnects. This is useful for re-subscribing to whatever events you wanted to subscribe to initially (in fact, you can probably use the same function/code you use when initializing the connection).
+The callback function should look something like this:
+
+.. code-block:: python
+
+    async def callback(streamer: DXLinkStreamer, arg1, arg2):
+        await streamer.subscribe(Quote, ['SPY'])
+
+The requirements are that the first parameter be the `DXLinkStreamer` instance, and the function should be asynchronous. Other than that, you have the flexibility to decide what arguments you want to use.
+This callback can then be used when creating the streamer:
+
+.. code-block:: python
+
+    async with DXLinkStreamer(session, reconnect_fn=callback, reconnect_args=(arg1, arg2)) as streamer:
+        # ...

--- a/docs/data-streamer.rst
+++ b/docs/data-streamer.rst
@@ -10,7 +10,7 @@ You can create a streamer using an active production session:
 .. code-block:: python
 
    from tastytrade import DXLinkStreamer
-   streamer = await DXLinkStreamer.create(session)
+   streamer = await DXLinkStreamer(session)
 
 Or, you can create a streamer using an asynchronous context manager:
 
@@ -110,7 +110,7 @@ For example, we can use the streamer to create an option chain that will continu
            # the `streamer_symbol` property is the symbol used by the streamer
            streamer_symbols = [o.streamer_symbol for o in options]
 
-           streamer = await DXLinkStreamer.create(session)
+           streamer = await DXLinkStreamer(session)
            # subscribe to quotes and greeks for all options on that date
            await streamer.subscribe(Quote, [symbol] + streamer_symbols)
            await streamer.subscribe(Greeks, streamer_symbols)
@@ -165,3 +165,5 @@ This callback can then be used when creating the streamer:
 
     async with DXLinkStreamer(session, reconnect_fn=callback, reconnect_args=(arg1, arg2)) as streamer:
         # ...
+
+The reconnection uses `websockets`' exponential backoff algorithm, which can be configured through environment variables `here <https://websockets.readthedocs.io/en/14.1/reference/variables.html>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "httpx>=0.27.2",
     "pandas-market-calendars>=4.4.1",
     "pydantic>=2.9.2",
-    "websockets>=14.1",
+    "websockets>=14.1,<15",
 ]
 
 [project.urls]
@@ -29,7 +29,7 @@ dev-dependencies = [
     "pytest-aio>=1.5.0",
     "pytest-cov>=5.0.0",
     "ruff>=0.6.9",
-    "pyright>=1.1.384",
+    "pyright>=1.1.390",
 ]
 
 [tool.setuptools.package-data]

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -225,7 +225,6 @@ class AlertStreamer:
     async def create(
         cls,
         session: Session,
-        *,
         reconnect_args: tuple[Any, ...] = (),
         reconnect_fn: Optional[Callable[..., Coroutine[Any, Any, None]]] = None,
     ) -> "AlertStreamer":
@@ -425,10 +424,16 @@ class DXLinkStreamer:
     async def create(
         cls,
         session: Session,
+        reconnect_args: tuple[Any, ...] = (),
         reconnect_fn: Optional[Callable[..., Coroutine[Any, Any, None]]] = None,
         ssl_context: SSLContext = create_default_context(),
     ) -> "DXLinkStreamer":
-        self = cls(session, reconnect_fn=reconnect_fn, ssl_context=ssl_context)
+        self = cls(
+            session,
+            reconnect_args=reconnect_args,
+            reconnect_fn=reconnect_fn,
+            ssl_context=ssl_context,
+        )
         return await self.__aenter__()
 
     async def __aexit__(self, *exc):

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 
 from tastytrade import Account, AlertStreamer, DXLinkStreamer
@@ -29,3 +30,38 @@ async def test_dxlink_streamer(session):
         await streamer.unsubscribe_candle(subs[0], "1d")
         await streamer.unsubscribe(Quote, [subs[0]])
         await streamer.unsubscribe_all(Quote)
+
+
+async def reconnect_alerts(streamer: AlertStreamer, ref: dict[str, bool]):
+    await streamer.subscribe_quote_alerts()
+    ref["test"] = True
+
+
+async def test_account_streamer_reconnect(session):
+    ref = {}
+    streamer = await AlertStreamer(
+        session, reconnect_args=(ref,), reconnect_fn=reconnect_alerts
+    )
+    await streamer.subscribe_public_watchlists()
+    await streamer.subscribe_user_messages(session)
+    accounts = Account.get_accounts(session)
+    await streamer.subscribe_accounts(accounts)
+    await streamer._websocket.close()  # type: ignore
+    await asyncio.sleep(3)
+    assert "test" in ref
+    streamer.close()
+
+
+async def reconnect_trades(streamer: DXLinkStreamer):
+    await streamer.subscribe(Trade, ["SPX"])
+
+
+async def test_dxlink_streamer_reconnect(session):
+    streamer = await DXLinkStreamer(session, reconnect_fn=reconnect_trades)
+    await streamer.subscribe(Quote, ["SPY"])
+    _ = await streamer.get_event(Quote)
+    await streamer._websocket.close()
+    await asyncio.sleep(3)
+    trade = await streamer.get_event(Trade)
+    assert trade.event_symbol == "SPX"
+    streamer.close()

--- a/uv.lock
+++ b/uv.lock
@@ -427,15 +427,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.384"
+version = "1.1.390"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/00/a23114619f9d005f4b0f35e037c76cee029174d090a6f73a355749c74f4a/pyright-1.1.384.tar.gz", hash = "sha256:25e54d61f55cbb45f1195ff89c488832d7a45d59f3e132f178fdf9ef6cafc706", size = 21956 }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/42/1e0392f35dd275f9f775baf7c86407cef7f6a0d9b8e099a93e5422a7e571/pyright-1.1.390.tar.gz", hash = "sha256:aad7f160c49e0fbf8209507a15e17b781f63a86a1facb69ca877c71ef2e9538d", size = 21950 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/4a/e7f4d71d194ba675f3577d11eebe4e17a592c4d1c3f9986d4b321ba3c809/pyright-1.1.384-py3-none-any.whl", hash = "sha256:f0b6f4db2da38f27aeb7035c26192f034587875f751b847e9ad42ed0c704ac9e", size = 18578 },
+    { url = "https://files.pythonhosted.org/packages/43/20/3f492ca789fb17962ad23619959c7fa642082621751514296c58de3bb801/pyright-1.1.390-py3-none-any.whl", hash = "sha256:ecebfba5b6b50af7c1a44c2ba144ba2ab542c227eb49bc1f16984ff714e0e110", size = 18579 },
 ]
 
 [[package]]
@@ -569,12 +569,12 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "pandas-market-calendars", specifier = ">=4.4.1" },
     { name = "pydantic", specifier = ">=2.9.2" },
-    { name = "websockets", specifier = ">=14.1" },
+    { name = "websockets", specifier = ">=14.1,<15" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pyright", specifier = ">=1.1.384" },
+    { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-aio", specifier = ">=1.5.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },


### PR DESCRIPTION
## Description
This PR adds optional callback functions to the constructors of `AlertStreamer` and `DXLinkStreamer`. These callbacks can be used to execute code upon a dropped connection being reestablished.
This is useful for re-subscribing to events or alerts.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [x] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
