### PR TITLE
add advanced order instructions, handle CancelledError in streamer tasks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "tastytrade"
 copyright = "2024, Graeme Holliday"
 author = "Graeme Holliday"
-release = "9.4"
+release = "9.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tastytrade"
-version = "9.4"
+version = "9.5"
 description = "An unofficial, sync/async SDK for Tastytrade!"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,7 +4,7 @@ API_URL = "https://api.tastyworks.com"
 BACKTEST_URL = "https://backtester.vast.tastyworks.com"
 CERT_URL = "https://api.cert.tastyworks.com"
 VAST_URL = "https://vast.tastyworks.com"
-VERSION = "9.4"
+VERSION = "9.5"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Optional, Union
 
+from pandas_market_calendars.calendar_registry import prop
 from pydantic import computed_field, field_serializer, model_validator
 
 from tastytrade import VERSION
@@ -221,6 +222,17 @@ class OrderRule(TastytradeJsonDataclass):
     order_conditions: list[OrderCondition]
 
 
+class AdvancedInstructions(TastytradeJsonDataclass):
+    """
+    Dataclass containing advanced order rules.
+    """
+
+    #: By default, if a position meant to be closed by a closing order is no longer
+    #: open, the API will turn it into an opening order. With this flag, the API would
+    #: instead discard the closing order.
+    strict_position_effect_validation: bool = False
+
+
 class NewOrder(TastytradeJsonDataclass):
     """
     Dataclass containing information about a new order. Also used for
@@ -241,6 +253,7 @@ class NewOrder(TastytradeJsonDataclass):
     partition_key: Optional[str] = None
     preflight_id: Optional[str] = None
     rules: Optional[OrderRule] = None
+    advanced_instructions: Optional[AdvancedInstructions] = None
 
     @computed_field
     @property

--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Optional, Union
 
-from pandas_market_calendars.calendar_registry import prop
 from pydantic import computed_field, field_serializer, model_validator
 
 from tastytrade import VERSION

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -409,7 +409,6 @@ class DXLinkStreamer:
         #: Variable number of arguments to pass to the reconnect function
         self.reconnect_args = reconnect_args
 
-        self._session = session
         self._authenticated = False
         self._wss_url = session.dxlink_url
         self._auth_token = session.streamer_token
@@ -663,7 +662,7 @@ class DXLinkStreamer:
         Removes existing subscription for given list of symbols.
         For candles, use :meth:`unsubscribe_candle` instead.
 
-        :param event_type: type of subscription to remove
+        :param event_class: type of subscription to remove
         :param symbols: list of symbols to unsubscribe from
         """
         if not self._authenticated:
@@ -682,11 +681,10 @@ class DXLinkStreamer:
         symbols: list[str],
         interval: str,
         start_time: datetime,
-        end_time: Optional[datetime] = None,
         extended_trading_hours: bool = False,
     ) -> None:
         """
-        Subscribes to time series data for the given symbol.
+        Subscribes to candle data for the given list of symbols.
 
         :param symbols: list of symbols to get data for
         :param interval:
@@ -715,8 +713,6 @@ class DXLinkStreamer:
                 for ticker in symbols
             ],
         }
-        if end_time is not None:
-            raise TastytradeError("End time no longer supported")
         await self._websocket.send(json.dumps(message))
 
     async def unsubscribe_candle(

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -49,7 +49,7 @@ async def test_account_streamer_reconnect(session):
     await streamer._websocket.close()  # type: ignore
     await asyncio.sleep(3)
     assert "test" in ref
-    streamer.close()
+    await streamer.close()
 
 
 async def reconnect_trades(streamer: DXLinkStreamer):
@@ -64,4 +64,4 @@ async def test_dxlink_streamer_reconnect(session):
     await asyncio.sleep(3)
     trade = await streamer.get_event(Trade)
     assert trade.event_symbol == "SPX"
-    streamer.close()
+    await streamer.close()

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "tastytrade"
-version = "9.4"
+version = "9.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Description
The cleanup in the streamer async iterator is currently messy, which can lead to lots of exceptions raised, which are harmless but annoying.

Also, this adds support for advanced order instructions, specifically `strict_position_effect_validation`, which fixes #178.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
