### PR TITLE
Fix the wrong usage in the example

### DIFF
--- a/docs/data-streamer.rst
+++ b/docs/data-streamer.rst
@@ -131,11 +131,11 @@ For example, we can use the streamer to create an option chain that will continu
 
        async def _update_greeks(self):
            async for e in self.streamer.listen(Greeks):
-               self.greeks[e.eventSymbol] = e
+               self.greeks[e.event_symbol] = e
       
        async def _update_quotes(self):
            async for e in self.streamer.listen(Quote):
-               self.quotes[e.eventSymbol] = e
+               self.quotes[e.event_symbol] = e
 
 Now, we can access the quotes and greeks at any time, and they'll be up-to-date with the live prices from the streamer:
 


### PR DESCRIPTION
## Description

The document uses a nonexisting property from the variable `e,` which should be `event_symbol.`

## Related issue(s)

It is not really causing issues but is misleading in the example.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
