### PR TITLE
add serialization for sessions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "tastytrade"
 copyright = "2024, Graeme Holliday"
 author = "Graeme Holliday"
-release = "9.6"
+release = "9.7"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tastytrade"
-version = "9.6"
+version = "9.7"
 description = "An unofficial, sync/async SDK for Tastytrade!"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,7 +4,7 @@ API_URL = "https://api.tastyworks.com"
 BACKTEST_URL = "https://backtester.vast.tastyworks.com"
 CERT_URL = "https://api.cert.tastyworks.com"
 VAST_URL = "https://vast.tastyworks.com"
-VERSION = "9.6"
+VERSION = "9.7"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -25,3 +25,9 @@ def test_destroy(credentials):
 async def test_destroy_async(credentials):
     session = Session(*credentials)
     await session.a_destroy()
+
+
+def test_serialize_deserialize(session):
+    data = session.serialize()
+    obj = Session.deserialize(data)
+    assert set(obj.__dict__.keys()) == set(session.__dict__.keys())

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "tastytrade"
-version = "9.5"
+version = "9.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Description
Adds `Session.serialize` and `Session.deserialize` functions, allowing for safely storing session objects and re-building sessions from stored ones.

## Related issue(s)
Inspired by #196

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [x] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
