### PR TITLE
Add note about using is_test and remember_token for additional sessions

### DIFF
--- a/docs/sessions.rst
+++ b/docs/sessions.rst
@@ -12,7 +12,7 @@ To create a production (real) session using your normal login:
    from tastytrade import Session
    session = Session('username', 'password')
 
-A certification (test) account can be created `here <https://developer.tastytrade.com/sandbox/>`_, then used to create a session:
+A certification (test) account can be created `here <https://developer.tastytrade.com/sandbox/>`_, then used to create a session.
 
 .. code-block:: python
 
@@ -27,3 +27,6 @@ You can make a session persistent by generating a remember token, which is valid
    remember_token = session.remember_token
    # remember token replaces the password for the next login
    new_session = Session('username', remember_token=remember_token)
+
+.. note::
+   If you used a certification (test) account to create the session associated with the `remember_token`, you must set `is_test=True` when creating subsequent sessions.


### PR DESCRIPTION
## Description
Added note about using `is_test` to Sessions docs when using `remember_token` from a test account.

## Related issue(s)
N/A

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [x] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
