### PR TITLE
add streamer refresh interval

### DIFF
--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,7 +4,9 @@ API_URL = "https://api.tastyworks.com"
 BACKTEST_URL = "https://backtester.vast.tastyworks.com"
 CERT_URL = "https://api.cert.tastyworks.com"
 VAST_URL = "https://vast.tastyworks.com"
-VERSION = "9.8"
+VERSION = "9.9"
+
+__version__ = VERSION
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -387,6 +387,7 @@ class DXLinkStreamer:
     def __init__(
         self,
         session: Session,
+        refresh_interval: float = 0.1,
         reconnect_args: tuple[Any, ...] = (),
         reconnect_fn: Optional[Callable[..., Coroutine[Any, Any, None]]] = None,
         ssl_context: SSLContext = create_default_context(),
@@ -404,6 +405,9 @@ class DXLinkStreamer:
             "Underlying": 17,
         }
         self._subscription_state: dict[str, str] = defaultdict(lambda: "CHANNEL_CLOSED")
+        #: Time in seconds between fetching new events from dxfeed. You can try a higher
+        #: value if processing quote updates quickly is not a high priority.
+        self.refresh_interval = refresh_interval
         #: An async function to be called upon reconnection. The first argument must be
         #: of type `DXLinkStreamer` and will be a reference to the streamer object.
         self.reconnect_fn = reconnect_fn
@@ -647,7 +651,7 @@ class DXLinkStreamer:
         message = {
             "type": "FEED_SETUP",
             "channel": self._channels[event_type],
-            "acceptAggregationPeriod": 10,
+            "acceptAggregationPeriod": self.refresh_interval,
             "acceptDataFormat": "COMPACT",
         }
 


### PR DESCRIPTION
## Description
Previously, the "acceptAggregationPeriod" of DXLink channels was hardcoded to a value of `10`, leading to unacceptably long delays between quotes in many scenarios. This fixes the problem by adding a new streamer parameter, `refresh_interval`, which allows each user to configure the value as desired. In addition, the default value is now `0.1`, which is close to real-time, rather than the unwieldy `10`, so most users will get immediate benefits without any changes.

## Related issue(s)
Fixes #211

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
