### PR TITLE
Feature/account balance add used derivative buying power

### DIFF
--- a/tastytrade/account.py
+++ b/tastytrade/account.py
@@ -77,6 +77,7 @@ class AccountBalance(TastytradeJsonDataclass):
     equity_offering_margin_requirement: Decimal
     long_bond_value: Decimal
     bond_margin_requirement: Decimal
+    used_derivative_buying_power: Decimal
     snapshot_date: date
     reg_t_margin_requirement: Decimal
     futures_overnight_margin_requirement: Decimal
@@ -142,6 +143,7 @@ class AccountBalanceSnapshot(TastytradeJsonDataclass):
     equity_offering_margin_requirement: Optional[Decimal] = None
     long_bond_value: Optional[Decimal] = None
     bond_margin_requirement: Optional[Decimal] = None
+    used_derivative_buying_power: Optional[Decimal] = None
 
     @model_validator(mode="before")
     @classmethod

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -623,7 +623,7 @@ class DXLinkStreamer:
         logger.debug("sending channel cancel: %s", message)
         await self._websocket.send(json.dumps(message))
 
-    async def _channel_request(self, event_type: str) -> None:
+    async def _channel_request(self, event_type: str, accept_aggregation_period: float = 10.0) -> None:
         message = {
             "type": "CHANNEL_REQUEST",
             "channel": self._channels[event_type],
@@ -641,13 +641,13 @@ class DXLinkStreamer:
             if time_out <= 0:
                 raise TastytradeError("Subscription channel not opened")
         # setup the feed
-        await self._channel_setup(event_type)
+        await self._channel_setup(event_type, accept_aggregation_period)
 
-    async def _channel_setup(self, event_type: str) -> None:
+    async def _channel_setup(self, event_type: str, accept_aggregation_period: float = 10.0) -> None:
         message = {
             "type": "FEED_SETUP",
             "channel": self._channels[event_type],
-            "acceptAggregationPeriod": 10,
+            "acceptAggregationPeriod": accept_aggregation_period,
             "acceptDataFormat": "COMPACT",
         }
 
@@ -689,6 +689,7 @@ class DXLinkStreamer:
         interval: str,
         start_time: datetime,
         extended_trading_hours: bool = False,
+        accept_aggregation_period: float = 10.0
     ) -> None:
         """
         Subscribes to candle data for the given list of symbols.
@@ -703,7 +704,7 @@ class DXLinkStreamer:
         """
         cls_str = "Candle"
         if self._subscription_state[cls_str] != "CHANNEL_OPENED":
-            await self._channel_request(cls_str)
+            await self._channel_request(cls_str, accept_aggregation_period)
         message = {
             "type": "FEED_SUBSCRIPTION",
             "channel": self._channels[cls_str],


### PR DESCRIPTION
## Description
#211

## Related issue(s)
Added optional configurable accept_aggregation_period preset to 10.0 to maintain original value

## Pre-merge checklist
- [x ] Code formatted correctly (check with `make lint`)
- [x ] Code implemented for both sync and async
- [x ] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [  ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
