### PR TITLE
overload to simplify classmethods

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,4 +31,6 @@ jobs:
       env:
         TT_USERNAME: ${{ secrets.TT_USERNAME }}
         TT_PASSWORD: ${{ secrets.TT_PASSWORD }}
+        TT_USERNAME_SANDBOX: ${{ secrets.TT_USERNAME_SANDBOX }}
+        TT_PASSWORD_SANDBOX: ${{ secrets.TT_PASSWORD_SANDBOX }}
         TT_ACCOUNT: ${{ secrets.TT_ACCOUNT }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A simple, reverse-engineered SDK for Tastytrade built on their (now mostly publi
 > Want to see the SDK in action? Check out [tastytrade-cli](https://github.com/tastyware/tastytrade-cli), a CLI for Tastytrade that showcases many of the SDK's features.
 
 > [!NOTE]
-> Do you use TradeStation? We're building a [brand-new SDK](https://github.com/tastyware/tradestation) for TS users, with many of the same features!
+> Want to build an advanced trading system? Check out [streaQ](https://github.com/tastyware/streaq), an async job queuing library for Python that's perfect for complex applications!
 
 ## Installation
 
@@ -66,13 +66,25 @@ Note that this is asynchronous code, so you can't run it as is unless you're usi
 ```python
 from tastytrade import Account
 
-account = Account.get_accounts(session)[0]
+account = Account.get(session)[0]
 positions = account.get_positions(session)
 print(positions[0])
 ```
 
 ```python
 >>> CurrentPosition(account_number='5WX01234', symbol='IAU', instrument_type=<InstrumentType.EQUITY: 'Equity'>, underlying_symbol='IAU', quantity=Decimal('20'), quantity_direction='Long', close_price=Decimal('37.09'), average_open_price=Decimal('37.51'), average_yearly_market_close_price=Decimal('37.51'), average_daily_market_close_price=Decimal('37.51'), multiplier=1, cost_effect=<PriceEffect.CREDIT: 'Credit'>, is_suppressed=False, is_frozen=False, realized_day_gain=Decimal('7.888'), realized_day_gain_date=datetime.date(2023, 5, 19), realized_today=Decimal('-0.512'), realized_today_date=datetime.date(2023, 5, 19), created_at=datetime.datetime(2023, 3, 31, 14, 38, 32, 58000, tzinfo=datetime.timezone.utc), updated_at=datetime.datetime(2023, 5, 19, 16, 56, 51, 920000, tzinfo=datetime.timezone.utc), mark=None, mark_price=None, restricted_quantity=Decimal('0'), expires_at=None, fixing_price=None, deliverable_type=None)
+```
+
+## Sync/async wrappers
+
+The code from above can be rewritten asynchronously:
+
+```python
+from tastytrade import Account
+
+account = (await Account.a_get(session))[0]
+positions = await account.a_get_positions(session)
+print(positions[0])
 ```
 
 ## Placing an order
@@ -83,8 +95,8 @@ from tastytrade import Account
 from tastytrade.instruments import Equity
 from tastytrade.order import NewOrder, OrderAction, OrderTimeInForce, OrderType
 
-account = Account.get_account(session, '5WX01234')
-symbol = Equity.get_equity(session, 'USO')
+account = Account.get(session, '5WX01234')
+symbol = Equity.get(session, 'USO')
 leg = symbol.build_leg(Decimal('5'), OrderAction.BUY_TO_OPEN)  # buy to open 5 shares
 
 order = NewOrder(

--- a/docs/account-streamer.rst
+++ b/docs/account-streamer.rst
@@ -14,7 +14,7 @@ Here's an example of setting up an account streamer to continuously wait for eve
     from tastytrade import Account, AlertStreamer, Watchlist
 
     async with AlertStreamer(session) as streamer:
-        accounts = Account.get_accounts(session)
+        accounts = Account.get(session)
 
         # updates to balances, orders, and positions
         await streamer.subscribe_accounts(accounts)
@@ -33,7 +33,7 @@ Probably the most important information the account streamer handles is order fi
     from tastytrade.order import PlacedOrder
 
     async with AlertStreamer(session) as streamer:
-        accounts = Account.get_accounts(session)
+        accounts = Account.get(session)
         await streamer.subscribe_accounts(accounts)
 
         async for order in streamer.listen(PlacedOrder):

--- a/docs/accounts.rst
+++ b/docs/accounts.rst
@@ -8,13 +8,13 @@ The easiest way to get an account is to grab all accounts associated with a spec
 .. code-block:: python
 
    from tastytrade import Account
-   accounts = Account.get_accounts(session)
+   accounts = Account.get(session)
 
 You can also get a specific account by its unique ID:
 
 .. code-block:: python
 
-   account = Account.get_account(session, '5WX01234')
+   account = Account.get(session, '5WX01234')
 
 The ``get_balances`` function can be used to obtain information about the current buying power and cash balance:
 

--- a/docs/data-streamer.rst
+++ b/docs/data-streamer.rst
@@ -31,7 +31,7 @@ Once you've created the streamer, you can subscribe/unsubscribe to events, like 
        await streamer.subscribe(Quote, subs_list)
        quotes = {}
        async for quote in streamer.listen(Quote):
-           quotes[quote.eventSymbol] = quote
+           quotes[quote.event_symbol] = quote
            if len(quotes) >= len(subs_list):
                break
        print(quotes)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ A simple, reverse-engineered, sync/async SDK for Tastytrade built on their (now 
    Want to see the SDK in action? Check out `tastytrade-cli <https://github.com/tastyware/tastytrade-cli>`_, a CLI for Tastytrade that showcases many of the SDK's features.
 
 .. note::
-   Do you use TradeStation? We're building a `brand-new SDK <https://github.com/tastyware/tradestation>`_ for TS users, with many of the same features!
+   Want to build an advanced trading system? Check out `streaQ <https://github.com/tastyware/streaq>`_, an async job queuing library for Python that's perfect for complex applications!
 
 .. toctree::
    :maxdepth: 2

--- a/docs/instruments.rst
+++ b/docs/instruments.rst
@@ -9,11 +9,11 @@ Initialization
 
 Instruments follow a basic schema for initialization. To create an instrument(s), use the classmethods for the desired type of instrument:
 
-- ``Cryptocurrency.get_cryptocurrency()``, ``Cryptocurrency.get_cryptocurrencies()``
-- ``Equity.get_equity()``, ``Equity.get_equities()``
-- ``Future.get_future()``, ``Future.get_futures()``
-- ``Option.get_option()``, ``Option.get_options()``
-- ``FutureOption.get_future_option()``, ``FutureOption.get_future_options()``
+- ``Cryptocurrency.get()``
+- ``Equity.get()``
+- ``Future.get()``
+- ``Option.get()``
+- ``FutureOption.get()``
 
 These functions take the session object as the first parameter, and the symbol (or list of symbols) as the second.
 Note that ETFs and indices are treated as equities for the purposes of the API.
@@ -22,9 +22,9 @@ Note that ETFs and indices are treated as equities for the purposes of the API.
 
    from tastytrade.instruments import Equity, FutureOption
 
-   equities = Equity.get_equities(session, ['SPY', 'AAPL'])
+   equities = Equity.get(session, ['SPY', 'AAPL'])
    print(equities[0].is_etf, equities[0].description)
-   future_option = FutureOption.get_future_option(session, './GCJ4 OG4G4 240223P1915')
+   future_option = FutureOption.get(session, './GCJ4 OG4G4 240223P1915')
    print(future_option.exchange)
 
 >>> (False, 'APPLE INC')
@@ -57,7 +57,7 @@ Alternatively, ``NestedOptionChain`` and ``NestedFutureOptionChain`` provide a s
 
    from tastytrade.instruments import NestedOptionChain
 
-   chain = NestedOptionChain.get_chain(session, 'SPY')
+   chain = NestedOptionChain.get(session, 'SPY')
    print(chain.expirations[0].strikes[0])
 
 >>> Strike(strike_price=Decimal('437.0'), call='SPY   240417C00437000', put='SPY   240417P00437000', call_streamer_symbol='.SPY240417C437', put_streamer_symbol='.SPY240417P437')

--- a/docs/orders.rst
+++ b/docs/orders.rst
@@ -11,8 +11,8 @@ Placing an order
    from tastytrade.instruments import Equity
    from tastytrade.order import *
 
-   account = Account.get_account(session, '5WX01234')
-   symbol = Equity.get_equity(session, 'USO')
+   account = Account.get(session, '5WX01234')
+   symbol = Equity.get(session, 'USO')
    leg = symbol.build_leg(Decimal('5'), OrderAction.BUY_TO_OPEN)  # buy to open 5 shares
 
    order = NewOrder(
@@ -71,7 +71,7 @@ To create an OTOCO order, you need an entry point order, a stop loss order, and 
    from tastytrade.instruments import Equity
    from tastytrade.order import *
 
-   symbol = Equity.get_equity(session, 'AAPL')
+   symbol = Equity.get(session, 'AAPL')
    opening = symbol.build_leg(Decimal(1), OrderAction.BUY_TO_OPEN) # buy to open 1 share
    closing = symbol.build_leg(Decimal(1), OrderAction.SELL_TO_CLOSE) # sell to close 1 share
 
@@ -103,7 +103,7 @@ An OCO order is similar, but has no trigger order. It's used to add a profit-tak
 
 .. code-block:: python
 
-   symbol = Equity.get_equity(session, 'SPY')
+   symbol = Equity.get(session, 'SPY')
    closing = symbol.build_leg(Decimal(10), OrderAction.SELL_TO_CLOSE) # sell to close 10 shares
 
    oco = NewComplexOrder(
@@ -135,7 +135,7 @@ Notional orders are slightly different from normal orders. Since the market will
 
 .. code-block:: python
 
-    symbol = Equity.get_equity(session, 'AAPL')
+    symbol = Equity.get(session, 'AAPL')
     order = NewOrder(
         time_in_force=OrderTimeInForce.DAY,
         order_type=OrderType.NOTIONAL_MARKET,

--- a/docs/sync-async.rst
+++ b/docs/sync-async.rst
@@ -10,7 +10,7 @@ Let's see how this looks:
     from tastytrade Account, Session
     session = Session(username, password)
     # using sync implementation
-    accounts = Account.get_accounts(session)
+    accounts = Account.get(session)
 
 The async implementation is similar:
 
@@ -19,7 +19,7 @@ The async implementation is similar:
     from tastytrade Account, Session
     session = Session(username, password)
     # using async implementation
-    accounts = await Account.a_get_accounts(session)
+    accounts = await Account.a_get(session)
 
 That's it! All sync methods have a parallel async method that starts with `a_`.
 

--- a/docs/watchlists.rst
+++ b/docs/watchlists.rst
@@ -1,8 +1,6 @@
 Watchlists
 ==========
 
-In this example assume ``MyWatchlist`` is an exising watchlist we want to modify.
-
 To use watchlists you'll need a production session:
 
 .. code-block:: python
@@ -10,12 +8,12 @@ To use watchlists you'll need a production session:
    from tastytrade import Session
    session = Session(user, password)
 
-Now we can fetch the watchlist:
+Let's fetch an existing watchlist:
 
 .. code-block:: python
 
-   from tastytrade import Watchlist
-   watchlist = Watchlist.get_private_watchlist(session, 'MyWatchlist')
+   from tastytrade import PrivateWatchlist
+   watchlist = PrivateWatchlist.get(session, 'MyWatchlist')
    print(watchlist.watchlist_entries)
 
 >>> [{'symbol': 'AAPL', 'instrument-type': 'Equity'}, {'symbol': 'MSFT', 'instrument-type': 'Equity'}]
@@ -25,18 +23,26 @@ To add a symbol to the watchlist:
 .. code-block:: python
 
    from tastytrade.instruments import InstrumentType
-   Watchlist.add_symbol('SPY', InstrumentType.EQUITY)
-   
+   watchlist.add_symbol('SPY', InstrumentType.EQUITY)
+
 In this case, the symbol is present locally, but not remotely, so we need to update the remote list:
 
 .. code-block:: python
 
-   watchlist.update_private_watchlist(session)
+   watchlist.update(session)
 
 We can also create a new watchlist from scratch, then publish it to the Tastytrade server:
 
 .. code-block:: python
 
-   new_watchlist = Watchlist(name='NewWatchlist')
+   new_watchlist = PrivateWatchlist(name='NewWatchlist')
    new_watchlist.add_symbol('USO', InstrumentType.EQUITY)
-   new_watchlist.upload_private_watchlist(session)
+   new_watchlist.upload(session)
+
+You can also fetch public watchlists:
+
+.. code-block:: python
+
+   from tastytrade import PublicWatchlist
+   public_watchlist = PublicWatchlist.get(session, "Tom's Watchlist")
+   print(public_watchlist.watchlist_entries)

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,7 +4,7 @@ API_URL = "https://api.tastyworks.com"
 BACKTEST_URL = "https://backtester.vast.tastyworks.com"
 CERT_URL = "https://api.cert.tastyworks.com"
 VAST_URL = "https://vast.tastyworks.com"
-VERSION = "9.13"
+VERSION = "10.0.0"
 
 __version__ = VERSION
 version_str = f"tastyware/tastytrade:v{VERSION}"

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -17,12 +17,10 @@ logger.setLevel(logging.DEBUG)
 from .account import Account
 from .session import Session
 from .streamer import AlertStreamer, DXLinkStreamer
-from .watchlists import Watchlist
 
 __all__ = [
     "Account",
     "AlertStreamer",
     "DXLinkStreamer",
     "Session",
-    "Watchlist",
 ]

--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union, overload
 
 from pydantic import model_validator
 from typing_extensions import Self
@@ -199,57 +199,67 @@ class Cryptocurrency(TradeableTastytradeJsonDataclass):
     destination_venue_symbols: list[DestinationVenueSymbol]
     streamer_symbol: Optional[str] = None
 
+    @overload
     @classmethod
-    async def a_get_cryptocurrencies(
-        cls, session: Session, symbols: list[str] = []
-    ) -> list[Self]:
+    async def a_get(
+        cls, session: Session, symbols: Optional[list[str]] = None
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str], None] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of cryptocurrency objects from the given symbols.
+        Returns a list of cryptocurrency objects from the given symbols,
+        or a single cryptocurrency if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: the symbols to get the cryptocurrencies for.
+        :param symbols: the symbol(s) to get the cryptocurrencies for.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F")
+            data = await session._a_get(f"/instruments/cryptocurrencies/{symbol}")
+            return cls(**data)
         params = {"symbol[]": symbols} if symbols else None
         data = await session._a_get("/instruments/cryptocurrencies", params=params)
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_cryptocurrencies(
-        cls, session: Session, symbols: list[str] = []
-    ) -> list[Self]:
+    def get(
+        cls, session: Session, symbols: Optional[list[str]] = None
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    def get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str], None] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of cryptocurrency objects from the given symbols.
+        Returns a list of cryptocurrency objects from the given symbols,
+        or a single cryptocurrency if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: the symbols to get the cryptocurrencies for.
+        :param symbols: the symbol(s) to get the cryptocurrencies for.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F")
+            data = session._get(f"/instruments/cryptocurrencies/{symbol}")
+            return cls(**data)
         params = {"symbol[]": symbols} if symbols else None
         data = session._get("/instruments/cryptocurrencies", params=params)
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_cryptocurrency(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Cryptocurrency object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the cryptocurrency for.
-        """
-        symbol = symbol.replace("/", "%2F")
-        data = await session._a_get(f"/instruments/cryptocurrencies/{symbol}")
-        return cls(**data)
-
-    @classmethod
-    def get_cryptocurrency(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Cryptocurrency object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the cryptocurrency for.
-        """
-        symbol = symbol.replace("/", "%2F")
-        data = session._get(f"/instruments/cryptocurrencies/{symbol}")
-        return cls(**data)
 
 
 class Equity(TradeableTastytradeJsonDataclass):
@@ -381,26 +391,47 @@ class Equity(TradeableTastytradeJsonDataclass):
 
         return equities
 
+    @overload
     @classmethod
-    async def a_get_equities(
+    async def a_get(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: list[str],
+        *,
         lendability: Optional[str] = None,
         is_index: Optional[bool] = None,
         is_etf: Optional[bool] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str]],
+        lendability: Optional[str] = None,
+        is_index: Optional[bool] = None,
+        is_etf: Optional[bool] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of Equity objects from the given symbols.
+        Returns a list of Equity objects from the given symbols, or a single
+        Equity object if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: the symbols to get the equities for.
+        :param symbols: the symbol(s) to get the equities for.
         :param lendability:
             the lendability of the equities; e.g. 'Easy To Borrow',
             'Locate Required', 'Preborrow'
         :param is_index: whether the equities are indexes.
         :param is_etf: whether the equities are ETFs.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F")
+            data = await session._a_get(f"/instruments/equities/{symbol}")
+            return cls(**data)
         params = {
             "symbol[]": symbols,
             "lendability": lendability,
@@ -413,26 +444,48 @@ class Equity(TradeableTastytradeJsonDataclass):
         )
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_equities(
+    def get(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: list[str],
+        *,
         lendability: Optional[str] = None,
         is_index: Optional[bool] = None,
         is_etf: Optional[bool] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    def get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str]],
+        *,
+        lendability: Optional[str] = None,
+        is_index: Optional[bool] = None,
+        is_etf: Optional[bool] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of Equity objects from the given symbols.
+        Returns a list of Equity objects from the given symbols, or a single
+        Equity object if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: the symbols to get the equities for.
+        :param symbols: the symbol(s) to get the equities for.
         :param lendability:
             the lendability of the equities; e.g. 'Easy To Borrow',
             'Locate Required', 'Preborrow'
         :param is_index: whether the equities are indexes.
         :param is_etf: whether the equities are ETFs.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F")
+            data = session._get(f"/instruments/equities/{symbol}")
+            return cls(**data)
         params = {
             "symbol[]": symbols,
             "lendability": lendability,
@@ -444,30 +497,6 @@ class Equity(TradeableTastytradeJsonDataclass):
             params={k: v for k, v in params.items() if v is not None},
         )
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_equity(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Equity object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the equity for.
-        """
-        symbol = symbol.replace("/", "%2F")
-        data = await session._a_get(f"/instruments/equities/{symbol}")
-        return cls(**data)
-
-    @classmethod
-    def get_equity(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Equity object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the equity for.
-        """
-        symbol = symbol.replace("/", "%2F")
-        data = session._get(f"/instruments/equities/{symbol}")
-        return cls(**data)
 
 
 class Option(TradeableTastytradeJsonDataclass):
@@ -503,22 +532,48 @@ class Option(TradeableTastytradeJsonDataclass):
             self._set_streamer_symbol()
         return self
 
+    @overload
     @classmethod
-    async def a_get_options(
+    async def a_get(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: list[str],
+        *,
         active: Optional[bool] = None,
         with_expired: Optional[bool] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(
+        cls, session: Session, symbols: str, *, active: Optional[bool] = None
+    ) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str]],
+        *,
+        active: Optional[bool] = None,
+        with_expired: Optional[bool] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of Option objects from the given symbols.
+        Returns a list of Option objects from the given symbols, or a single
+        Option object if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: the OCC symbols to get the options for.
+        :param symbols: the OCC symbol(s) to get the options for.
         :param active: whether the options are active.
         :param with_expired: whether to include expired options.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F")
+            params = {"active": active} if active is not None else None
+            data = await session._a_get(
+                f"/instruments/equity-options/{symbol}", params=params
+            )
+            return cls(**data)
         params = {"symbol[]": symbols, "active": active, "with-expired": with_expired}
         data = await session._a_get(
             "/instruments/equity-options",
@@ -526,60 +581,52 @@ class Option(TradeableTastytradeJsonDataclass):
         )
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_options(
+    def get(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: list[str],
+        *,
         active: Optional[bool] = None,
         with_expired: Optional[bool] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(
+        cls, session: Session, symbols: str, *, active: Optional[bool] = None
+    ) -> Self: ...
+
+    @classmethod
+    def get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str]],
+        *,
+        active: Optional[bool] = None,
+        with_expired: Optional[bool] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of Option objects from the given symbols.
+        Returns a list of Option objects from the given symbols, or a single
+        Option object if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: the OCC symbols to get the options for.
+        :param symbols: the OCC symbol(s) to get the options for.
         :param active: whether the options are active.
         :param with_expired: whether to include expired options.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F")
+            params = {"active": active} if active is not None else None
+            data = session._get(f"/instruments/equity-options/{symbol}", params=params)
+            return cls(**data)
         params = {"symbol[]": symbols, "active": active, "with-expired": with_expired}
         data = session._get(
             "/instruments/equity-options",
             params={k: v for k, v in params.items() if v is not None},
         )
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_option(
-        cls, session: Session, symbol: str, active: Optional[bool] = None
-    ) -> Self:
-        """
-        Returns a Option object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the option for, OCC format
-        """
-        symbol = symbol.replace("/", "%2F")
-        params = {"active": active} if active is not None else None
-        data = await session._a_get(
-            f"/instruments/equity-options/{symbol}", params=params
-        )
-        return cls(**data)
-
-    @classmethod
-    def get_option(
-        cls, session: Session, symbol: str, active: Optional[bool] = None
-    ) -> Self:
-        """
-        Returns a Option object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the option for, OCC format
-        """
-        symbol = symbol.replace("/", "%2F")
-        params = {"active": active} if active is not None else None
-        data = session._get(f"/instruments/equity-options/{symbol}", params=params)
-        return cls(**data)
 
     def _set_streamer_symbol(self) -> None:
         if self.strike_price % 1 == 0:
@@ -660,7 +707,7 @@ class NestedOptionChain(TastytradeJsonDataclass):
     deliverables: Optional[list[Deliverable]] = None
 
     @classmethod
-    async def a_get_chain(cls, session: Session, symbol: str) -> list[Self]:
+    async def a_get(cls, session: Session, symbol: str) -> list[Self]:
         """
         Gets the option chain for the given symbol in nested format.
 
@@ -672,7 +719,7 @@ class NestedOptionChain(TastytradeJsonDataclass):
         return [cls(**item) for item in data["items"]]
 
     @classmethod
-    def get_chain(cls, session: Session, symbol: str) -> list[Self]:
+    def get(cls, session: Session, symbol: str) -> list[Self]:
         """
         Gets the option chain for the given symbol in nested format.
 
@@ -724,57 +771,65 @@ class FutureProduct(TastytradeJsonDataclass):
     legacy_exchange_code: Optional[str] = None
     option_products: Optional[list["FutureOptionProduct"]] = None
 
+    @overload
     @classmethod
-    async def a_get_future_products(cls, session: Session) -> list[Self]:
+    async def a_get(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(
+        cls, session: Session, code: str, exchange: str = "CME"
+    ) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls, session: Session, code: Optional[str] = None, exchange: str = "CME"
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of FutureProduct objects available.
+        Returns a list of FutureProduct objects available, or a single
+        FutureProduct object if a code is provided.
 
         :param session: the session to use for the request.
+        :param code: the product code, e.g. 'ES'
+        :param exchange:
+            the exchange to fetch from: 'CME', 'SMALLS', 'CFE', 'CBOED'
         """
+        if code:
+            code = code.replace("/", "")
+            data = await session._a_get(
+                f"/instruments/future-products/{exchange}/{code}"
+            )
+            return cls(**data)
         data = await session._a_get("/instruments/future-products")
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_future_products(cls, session: Session) -> list[Self]:
+    def get(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, code: str, exchange: str = "CME") -> Self: ...
+
+    @classmethod
+    def get(
+        cls, session: Session, code: Optional[str] = None, exchange: str = "CME"
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of FutureProduct objects available.
+        Returns a list of FutureProduct objects available, or a single
+        FutureProduct object if a code is provided.
 
         :param session: the session to use for the request.
+        :param code: the product code, e.g. 'ES'
+        :param exchange:
+            the exchange to fetch from: 'CME', 'SMALLS', 'CFE', 'CBOED'
         """
+        if code:
+            code = code.replace("/", "")
+            data = session._get(f"/instruments/future-products/{exchange}/{code}")
+            return cls(**data)
         data = session._get("/instruments/future-products")
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_future_product(
-        cls, session: Session, code: str, exchange: str = "CME"
-    ) -> Self:
-        """
-        Returns a FutureProduct object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param code: the product code, e.g. 'ES'
-        :param exchange:
-            the exchange to fetch from: 'CME', 'SMALLS', 'CFE', 'CBOED'
-        """
-        code = code.replace("/", "")
-        data = await session._a_get(f"/instruments/future-products/{exchange}/{code}")
-        return cls(**data)
-
-    @classmethod
-    def get_future_product(
-        cls, session: Session, code: str, exchange: str = "CME"
-    ) -> Self:
-        """
-        Returns a FutureProduct object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param code: the product code, e.g. 'ES'
-        :param exchange:
-            the exchange to fetch from: 'CME', 'SMALLS', 'CFE', 'CBOED'
-        """
-        code = code.replace("/", "")
-        data = session._get(f"/instruments/future-products/{exchange}/{code}")
-        return cls(**data)
 
 
 class Future(TradeableTastytradeJsonDataclass):
@@ -815,24 +870,43 @@ class Future(TradeableTastytradeJsonDataclass):
     option_tick_sizes: Optional[list[TickSize]] = None
     spread_tick_sizes: Optional[list[TickSize]] = None
 
+    @overload
     @classmethod
-    async def a_get_futures(
+    async def a_get(
         cls,
         session: Session,
         symbols: Optional[list[str]] = None,
+        *,
         product_codes: Optional[list[str]] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str], None] = None,
+        *,
+        product_codes: Optional[list[str]] = None,
+    ) -> Union[Self, list[Self]]:
         """
         Returns a list of Future objects from the given symbols
         or product codes.
 
         :param session: the session to use for the request.
         :param symbols:
-            symbols of the futures, e.g. 'ESZ9', '/ESZ9'.
+            symbol(s) of the futures, e.g. 'ESZ9', '/ESZ9'.
         :param product_codes:
             the product codes of the futures, e.g. 'ES', '6A'. Ignored if
             symbols are provided.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "")
+            data = await session._a_get(f"/instruments/futures/{symbol}")
+            return cls(**data)
         params = {"symbol[]": symbols, "product-code[]": product_codes}
         data = await session._a_get(
             "/instruments/futures",
@@ -840,54 +914,49 @@ class Future(TradeableTastytradeJsonDataclass):
         )
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_futures(
+    def get(
         cls,
         session: Session,
         symbols: Optional[list[str]] = None,
+        *,
         product_codes: Optional[list[str]] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    def get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str], None] = None,
+        *,
+        product_codes: Optional[list[str]] = None,
+    ) -> Union[Self, list[Self]]:
         """
         Returns a list of Future objects from the given symbols
         or product codes.
 
         :param session: the session to use for the request.
         :param symbols:
-            symbols of the futures, e.g. 'ESZ9', '/ESZ9'.
+            symbol(s) of the futures, e.g. 'ESZ9', '/ESZ9'.
         :param product_codes:
             the product codes of the futures, e.g. 'ES', '6A'. Ignored if
             symbols are provided.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "")
+            data = session._get(f"/instruments/futures/{symbol}")
+            return cls(**data)
         params = {"symbol[]": symbols, "product-code[]": product_codes}
         data = session._get(
             "/instruments/futures",
             params={k: v for k, v in params.items() if v is not None},
         )
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_future(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Future object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the future for.
-        """
-        symbol = symbol.replace("/", "")
-        data = await session._a_get(f"/instruments/futures/{symbol}")
-        return cls(**data)
-
-    @classmethod
-    def get_future(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Future object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the future for.
-        """
-        symbol = symbol.replace("/", "")
-        data = session._get(f"/instruments/futures/{symbol}")
-        return cls(**data)
 
 
 class FutureOptionProduct(TastytradeJsonDataclass):
@@ -915,59 +984,71 @@ class FutureOptionProduct(TastytradeJsonDataclass):
     legacy_code: Optional[str] = None
     clearport_code: Optional[str] = None
 
+    @overload
     @classmethod
-    async def a_get_future_option_products(cls, session: Session) -> list[Self]:
+    async def a_get(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(
+        cls, session: Session, root_symbol: str, exchange: str = "CME"
+    ) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls,
+        session: Session,
+        root_symbol: Optional[str] = None,
+        exchange: str = "CME",
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of FutureOptionProduct objects available.
+        Returns a list of FutureOptionProduct objects available, or a single
+        FutureOptionProduct object if a root symbol is provided.
 
         :param session: the session to use for the request.
+        :param root_symbol: the root symbol of the future option
+        :param exchange: the exchange to get the product from
         """
+        if root_symbol:
+            root_symbol = root_symbol.replace("/", "")
+            data = await session._a_get(
+                f"/instruments/future-option-products/{exchange}/{root_symbol}"
+            )
+            return cls(**data)
         data = await session._a_get("/instruments/future-option-products")
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_future_option_products(cls, session: Session) -> list[Self]:
+    def get(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, root_symbol: str, exchange: str = "CME") -> Self: ...
+
+    @classmethod
+    def get(
+        cls,
+        session: Session,
+        root_symbol: Optional[str] = None,
+        exchange: str = "CME",
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of FutureOptionProduct objects available.
+        Returns a list of FutureOptionProduct objects available, or a single
+        FutureOptionProduct object if a root symbol is provided.
 
         :param session: the session to use for the request.
+        :param root_symbol: the root symbol of the future option
+        :param exchange: the exchange to get the product from
         """
+        if root_symbol:
+            root_symbol = root_symbol.replace("/", "")
+            data = session._get(
+                f"/instruments/future-option-products/{exchange}/{root_symbol}"
+            )
+            return cls(**data)
         data = session._get("/instruments/future-option-products")
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_future_option_product(
-        cls, session: Session, root_symbol: str, exchange: str = "CME"
-    ) -> Self:
-        """
-        Returns a FutureOptionProduct object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param code: the root symbol of the future option
-        :param exchange: the exchange to get the product from
-        """
-        root_symbol = root_symbol.replace("/", "")
-        data = await session._a_get(
-            f"/instruments/future-option-products/{exchange}/{root_symbol}"
-        )
-        return cls(**data)
-
-    @classmethod
-    def get_future_option_product(
-        cls, session: Session, root_symbol: str, exchange: str = "CME"
-    ) -> Self:
-        """
-        Returns a FutureOptionProduct object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param code: the root symbol of the future option
-        :param exchange: the exchange to get the product from
-        """
-        root_symbol = root_symbol.replace("/", "")
-        data = session._get(
-            f"/instruments/future-option-products/{exchange}/{root_symbol}"
-        )
-        return cls(**data)
 
 
 class FutureOption(TradeableTastytradeJsonDataclass):
@@ -1010,30 +1091,51 @@ class FutureOption(TradeableTastytradeJsonDataclass):
     instrument_type: InstrumentType = InstrumentType.FUTURE_OPTION
     future_option_product: Optional["FutureOptionProduct"] = None
 
+    @overload
     @classmethod
-    async def a_get_future_options(
+    async def a_get(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: list[str],
+        *,
         root_symbol: Optional[str] = None,
         expiration_date: Optional[date] = None,
         option_type: Optional[OptionType] = None,
         strike_price: Optional[Decimal] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str]],
+        *,
+        root_symbol: Optional[str] = None,
+        expiration_date: Optional[date] = None,
+        option_type: Optional[OptionType] = None,
+        strike_price: Optional[Decimal] = None,
+    ) -> Union[Self, list[Self]]:
         """
         Returns a list of FutureOption objects from the given symbols.
 
-        NOTE: Last I checked, all of the parameters are bugged except
-        for `symbols`.
+        NOTE: many of the parameters are bugged, maybe Tasty will fix?
 
         :param session: the session to use for the request.
-        :param symbols: the Tastytrade symbols to filter by.
+        :param symbols: the Tastytrade symbol(s) to filter by.
         :param root_symbol:
             the root symbol to get the future options for, e.g. 'EW3', 'SO'
         :param expiration_date: the expiration date for the future options.
         :param option_type: the option type to filter by.
         :param strike_price: the strike price to filter by.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F").replace(" ", "%20")
+            data = await session._a_get(f"/instruments/future-options/{symbol}")
+            return cls(**data)
         params = {
             "symbol[]": symbols,
             "option-root-symbol": root_symbol,
@@ -1047,30 +1149,51 @@ class FutureOption(TradeableTastytradeJsonDataclass):
         )
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_future_options(
+    def get(
         cls,
         session: Session,
-        symbols: Optional[list[str]] = None,
+        symbols: list[str],
+        *,
         root_symbol: Optional[str] = None,
         expiration_date: Optional[date] = None,
         option_type: Optional[OptionType] = None,
         strike_price: Optional[Decimal] = None,
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    def get(
+        cls,
+        session: Session,
+        symbols: Union[str, list[str]],
+        *,
+        root_symbol: Optional[str] = None,
+        expiration_date: Optional[date] = None,
+        option_type: Optional[OptionType] = None,
+        strike_price: Optional[Decimal] = None,
+    ) -> Union[Self, list[Self]]:
         """
         Returns a list of FutureOption objects from the given symbols.
 
-        NOTE: Last I checked, all of the parameters are bugged except
-        for `symbols`.
+        NOTE: many of the parameters are bugged, maybe Tasty will fix?
 
         :param session: the session to use for the request.
-        :param symbols: the Tastytrade symbols to filter by.
+        :param symbols: the Tastytrade symbol(s) to filter by.
         :param root_symbol:
             the root symbol to get the future options for, e.g. 'EW3', 'SO'
         :param expiration_date: the expiration date for the future options.
         :param option_type: the option type to filter by.
         :param strike_price: the strike price to filter by.
         """
+        if isinstance(symbols, str):
+            symbol = symbols.replace("/", "%2F").replace(" ", "%20")
+            data = session._get(f"/instruments/future-options/{symbol}")
+            return cls(**data)
         params = {
             "symbol[]": symbols,
             "option-root-symbol": root_symbol,
@@ -1083,30 +1206,6 @@ class FutureOption(TradeableTastytradeJsonDataclass):
             params={k: v for k, v in params.items() if v is not None},
         )
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_future_option(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a FutureOption object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the option for, Tastytrade format
-        """
-        symbol = symbol.replace("/", "%2F").replace(" ", "%20")
-        data = await session._a_get(f"/instruments/future-options/{symbol}")
-        return cls(**data)
-
-    @classmethod
-    def get_future_option(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a FutureOption object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the option for, Tastytrade format
-        """
-        symbol = symbol.replace("/", "%2F").replace(" ", "%20")
-        data = session._get(f"/instruments/future-options/{symbol}")
-        return cls(**data)
 
 
 class NestedFutureOptionSubchain(TastytradeJsonDataclass):
@@ -1173,55 +1272,61 @@ class Warrant(TastytradeJsonDataclass):
     active: bool
     cusip: Optional[str] = None
 
+    @overload
     @classmethod
-    async def a_get_warrants(
+    async def a_get(
         cls, session: Session, symbols: Optional[list[str]] = None
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls, session: Session, symbols: Union[str, list[str], None] = None
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of Warrant objects from the given symbols.
+        Returns a list of Warrant objects from the given symbols, or a single
+        Warrant object if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: symbols of the warrants, e.g. 'NKLAW'
+        :param symbols: symbol(s) of the warrants, e.g. 'NKLAW'
         """
+        if isinstance(symbols, str):
+            data = await session._a_get(f"/instruments/warrants/{symbols}")
+            return cls(**data)
         params = {"symbol[]": symbols} if symbols else None
         data = await session._a_get("/instruments/warrants", params=params)
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_warrants(
+    def get(
         cls, session: Session, symbols: Optional[list[str]] = None
-    ) -> list[Self]:
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, symbols: str) -> Self: ...
+
+    @classmethod
+    def get(
+        cls, session: Session, symbols: Union[str, list[str], None] = None
+    ) -> Union[Self, list[Self]]:
         """
-        Returns a list of Warrant objects from the given symbols.
+        Returns a list of Warrant objects from the given symbols, or a single
+        Warrant object if a list is not provided.
 
         :param session: the session to use for the request.
-        :param symbols: symbols of the warrants, e.g. 'NKLAW'
+        :param symbols: symbol(s) of the warrants, e.g. 'NKLAW'
         """
+        if isinstance(symbols, str):
+            data = session._get(f"/instruments/warrants/{symbols}")
+            return cls(**data)
         params = {"symbol[]": symbols} if symbols else None
         data = session._get("/instruments/warrants", params=params)
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_warrant(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Warrant object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the warrant for.
-        """
-        data = await session._a_get(f"/instruments/warrants/{symbol}")
-        return cls(**data)
-
-    @classmethod
-    def get_warrant(cls, session: Session, symbol: str) -> Self:
-        """
-        Returns a Warrant object from the given symbol.
-
-        :param session: the session to use for the request.
-        :param symbol: the symbol to get the warrant for.
-        """
-        data = session._get(f"/instruments/warrants/{symbol}")
-        return cls(**data)
 
 
 # fix pydantic forward references

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
-from httpx._models import Response
+from httpx._models import Response  # type: ignore
 from pandas_market_calendars import get_calendar
 from pydantic import BaseModel, ConfigDict
 

--- a/tastytrade/watchlists.py
+++ b/tastytrade/watchlists.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union, overload
 
 from typing_extensions import Self
 
@@ -29,47 +29,59 @@ class PairsWatchlist(TastytradeJsonDataclass):
     order_index: int
     pairs_equations: list[Pair]
 
+    @overload
     @classmethod
-    async def a_get_pairs_watchlists(cls, session: Session) -> list[Self]:
+    async def a_get(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(cls, session: Session, name: str) -> Self: ...
+
+    @classmethod
+    async def a_get(
+        cls,
+        session: Session,
+        name: Optional[str] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Fetches a list of all Tastytrade public pairs watchlists.
+        Fetches a list of all Tastytrade public pairs watchlists, or a specific one if
+        a name is provided.
 
         :param session: the session to use for the request.
+        :param name: the name of the pairs watchlist to fetch.
         """
+        if name:
+            data = await session._a_get(f"/pairs-watchlists/{name}")
+            return cls(**data)
         data = await session._a_get("/pairs-watchlists")
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_pairs_watchlists(cls, session: Session) -> list[Self]:
+    def get(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get(cls, session: Session, name: str) -> Self: ...
+
+    @classmethod
+    def get(
+        cls,
+        session: Session,
+        name: Optional[str] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Fetches a list of all Tastytrade public pairs watchlists.
+        Fetches a list of all Tastytrade public pairs watchlists, or a specific one if
+        a name is provided.
 
         :param session: the session to use for the request.
+        :param name: the name of the pairs watchlist to fetch.
         """
+        if name:
+            data = session._get(f"/pairs-watchlists/{name}")
+            return cls(**data)
         data = session._get("/pairs-watchlists")
         return [cls(**i) for i in data["items"]]
-
-    @classmethod
-    async def a_get_pairs_watchlist(cls, session: Session, name: str) -> Self:
-        """
-        Fetches a Tastytrade public pairs watchlist by name.
-
-        :param session: the session to use for the request.
-        :param name: the name of the pairs watchlist to fetch.
-        """
-        data = await session._a_get(f"/pairs-watchlists/{name}")
-        return cls(**data)
-
-    @classmethod
-    def get_pairs_watchlist(cls, session: Session, name: str) -> Self:
-        """
-        Fetches a Tastytrade public pairs watchlist by name.
-
-        :param session: the session to use for the request.
-        :param name: the name of the pairs watchlist to fetch.
-        """
-        data = session._get(f"/pairs-watchlists/{name}")
-        return cls(**data)
 
 
 class Watchlist(TastytradeJsonDataclass):
@@ -83,100 +95,124 @@ class Watchlist(TastytradeJsonDataclass):
     group_name: str = "default"
     order_index: int = 9999
 
+    @overload
     @classmethod
-    async def a_get_public_watchlists(
-        cls, session: Session, counts_only: bool = False
-    ) -> list[Self]:
+    async def a_get_public(
+        cls, session: Session, *, counts_only: bool = False
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get_public(cls, session: Session, name: str) -> Self: ...
+
+    @classmethod
+    async def a_get_public(
+        cls,
+        session: Session,
+        name: Optional[str] = None,
+        *,
+        counts_only: bool = False,
+    ) -> Union[Self, list[Self]]:
         """
-        Fetches a list of all Tastytrade public watchlists.
+        Fetches a list of all Tastytrade public watchlists, or a specific one if
+        a name is provided.
 
         :param session: the session to use for the request.
         :param counts_only: whether to only fetch the counts of the watchlists.
         """
+        if name:
+            data = await session._a_get(f"/public-watchlists/{name}")
+            return cls(**data)
         data = await session._a_get(
             "/public-watchlists", params={"counts-only": counts_only}
         )
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_public_watchlists(
-        cls, session: Session, counts_only: bool = False
-    ) -> list[Self]:
+    def get_public(
+        cls, session: Session, *, counts_only: bool = False
+    ) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get_public(cls, session: Session, name: str) -> Self: ...
+
+    @classmethod
+    def get_public(
+        cls,
+        session: Session,
+        name: Optional[str] = None,
+        *,
+        counts_only: bool = False,
+    ) -> Union[Self, list[Self]]:
         """
-        Fetches a list of all Tastytrade public watchlists.
+        Fetches a list of all Tastytrade public watchlists, or a specific one if
+        a name is provided.
 
         :param session: the session to use for the request.
         :param counts_only: whether to only fetch the counts of the watchlists.
         """
+        if name:
+            data = session._get(f"/public-watchlists/{name}")
+            return cls(**data)
         data = session._get("/public-watchlists", params={"counts-only": counts_only})
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    async def a_get_public_watchlist(cls, session: Session, name: str) -> Self:
+    async def a_get_private(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get_private(cls, session: Session, name: str) -> Self: ...
+
+    @classmethod
+    async def a_get_private(
+        cls,
+        session: Session,
+        name: Optional[str] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Fetches a Tastytrade public watchlist by name.
+        Fetches the user's private watchlists, or a specific one if a name is provided.
 
         :param session: the session to use for the request.
         :param name: the name of the watchlist to fetch.
         """
-        data = await session._a_get(f"/public-watchlists/{name}")
-        return cls(**data)
-
-    @classmethod
-    def get_public_watchlist(cls, session: Session, name: str) -> Self:
-        """
-        Fetches a Tastytrade public watchlist by name.
-
-        :param session: the session to use for the request.
-        :param name: the name of the watchlist to fetch.
-        """
-        data = session._get(f"/public-watchlists/{name}")
-        return cls(**data)
-
-    @classmethod
-    async def a_get_private_watchlists(cls, session: Session) -> list[Self]:
-        """
-        Fetches a the user's private watchlists.
-
-        :param session: the session to use for the request.
-        """
+        if name:
+            data = await session._a_get(f"/watchlists/{name}")
+            return cls(**data)
         data = await session._a_get("/watchlists")
         return [cls(**i) for i in data["items"]]
 
+    @overload
     @classmethod
-    def get_private_watchlists(cls, session: Session) -> list[Self]:
+    def get_private(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    def get_private(cls, session: Session, name: str) -> Self: ...
+
+    @classmethod
+    def get_private(
+        cls,
+        session: Session,
+        name: Optional[str] = None,
+    ) -> Union[Self, list[Self]]:
         """
-        Fetches a the user's private watchlists.
+        Fetches the user's private watchlists, or a specific one if a name is provided.
 
         :param session: the session to use for the request.
+        :param name: the name of the watchlist to fetch.
         """
+        if name:
+            data = session._get(f"/watchlists/{name}")
+            return cls(**data)
         data = session._get("/watchlists")
         return [cls(**i) for i in data["items"]]
 
     @classmethod
-    async def a_get_private_watchlist(cls, session: Session, name: str) -> Self:
-        """
-        Fetches a user's watchlist by name.
-
-        :param session: the session to use for the request.
-        :param name: the name of the watchlist to fetch.
-        """
-        data = await session._a_get(f"/watchlists/{name}")
-        return cls(**data)
-
-    @classmethod
-    def get_private_watchlist(cls, session: Session, name: str) -> Self:
-        """
-        Fetches a user's watchlist by name.
-
-        :param session: the session to use for the request.
-        :param name: the name of the watchlist to fetch.
-        """
-        data = session._get(f"/watchlists/{name}")
-        return cls(**data)
-
-    @classmethod
-    async def a_remove_private_watchlist(cls, session: Session, name: str) -> None:
+    async def a_remove_private(cls, session: Session, name: str) -> None:
         """
         Deletes the named private watchlist.
 
@@ -186,7 +222,7 @@ class Watchlist(TastytradeJsonDataclass):
         await session._a_delete(f"/watchlists/{name}")
 
     @classmethod
-    def remove_private_watchlist(cls, session: Session, name: str) -> None:
+    def remove_private(cls, session: Session, name: str) -> None:
         """
         Deletes the named private watchlist.
 
@@ -195,7 +231,7 @@ class Watchlist(TastytradeJsonDataclass):
         """
         session._delete(f"/watchlists/{name}")
 
-    async def a_upload_private_watchlist(self, session: Session) -> None:
+    async def a_upload_private(self, session: Session) -> None:
         """
         Creates a private remote watchlist identical to this local one.
 
@@ -203,7 +239,7 @@ class Watchlist(TastytradeJsonDataclass):
         """
         await session._a_post("/watchlists", json=self.model_dump(by_alias=True))
 
-    def upload_private_watchlist(self, session: Session) -> None:
+    def upload_private(self, session: Session) -> None:
         """
         Creates a private remote watchlist identical to this local one.
 
@@ -211,7 +247,7 @@ class Watchlist(TastytradeJsonDataclass):
         """
         session._post("/watchlists", json=self.model_dump(by_alias=True))
 
-    async def a_update_private_watchlist(self, session: Session) -> None:
+    async def a_update_private(self, session: Session) -> None:
         """
         Updates the existing private remote watchlist.
 
@@ -221,7 +257,7 @@ class Watchlist(TastytradeJsonDataclass):
             f"/watchlists/{self.name}", json=self.model_dump(by_alias=True)
         )
 
-    def update_private_watchlist(self, session: Session) -> None:
+    def update_private(self, session: Session) -> None:
         """
         Updates the existing private remote watchlist.
 

--- a/tastytrade/watchlists.py
+++ b/tastytrade/watchlists.py
@@ -85,28 +85,29 @@ class PairsWatchlist(TastytradeJsonDataclass):
 
 
 class Watchlist(TastytradeJsonDataclass):
-    """
-    Dataclass that represents a watchlist object (public or private),
-    with functions to update, publish, modify and remove watchlists.
-    """
-
     name: str
     watchlist_entries: Optional[list[dict[str, Any]]] = None
     group_name: str = "default"
     order_index: int = 9999
 
+
+class PublicWatchlist(Watchlist):
+    """
+    Dataclass that contains symbols from a public watchlist.
+    """
+
     @overload
     @classmethod
-    async def a_get_public(
+    async def a_get(
         cls, session: Session, *, counts_only: bool = False
     ) -> list[Self]: ...
 
     @overload
     @classmethod
-    async def a_get_public(cls, session: Session, name: str) -> Self: ...
+    async def a_get(cls, session: Session, name: str) -> Self: ...
 
     @classmethod
-    async def a_get_public(
+    async def a_get(
         cls,
         session: Session,
         name: Optional[str] = None,
@@ -130,16 +131,14 @@ class Watchlist(TastytradeJsonDataclass):
 
     @overload
     @classmethod
-    def get_public(
-        cls, session: Session, *, counts_only: bool = False
-    ) -> list[Self]: ...
+    def get(cls, session: Session, *, counts_only: bool = False) -> list[Self]: ...
 
     @overload
     @classmethod
-    def get_public(cls, session: Session, name: str) -> Self: ...
+    def get(cls, session: Session, name: str) -> Self: ...
 
     @classmethod
-    def get_public(
+    def get(
         cls,
         session: Session,
         name: Optional[str] = None,
@@ -159,16 +158,23 @@ class Watchlist(TastytradeJsonDataclass):
         data = session._get("/public-watchlists", params={"counts-only": counts_only})
         return [cls(**i) for i in data["items"]]
 
-    @overload
-    @classmethod
-    async def a_get_private(cls, session: Session) -> list[Self]: ...
+
+class PrivateWatchlist(Watchlist):
+    """
+    Dataclass that contains a private watchlist object, with functions to
+    update, publish, modify and remove watchlists.
+    """
 
     @overload
     @classmethod
-    async def a_get_private(cls, session: Session, name: str) -> Self: ...
+    async def a_get(cls, session: Session) -> list[Self]: ...
+
+    @overload
+    @classmethod
+    async def a_get(cls, session: Session, name: str) -> Self: ...
 
     @classmethod
-    async def a_get_private(
+    async def a_get(
         cls,
         session: Session,
         name: Optional[str] = None,
@@ -187,14 +193,14 @@ class Watchlist(TastytradeJsonDataclass):
 
     @overload
     @classmethod
-    def get_private(cls, session: Session) -> list[Self]: ...
+    def get(cls, session: Session) -> list[Self]: ...
 
     @overload
     @classmethod
-    def get_private(cls, session: Session, name: str) -> Self: ...
+    def get(cls, session: Session, name: str) -> Self: ...
 
     @classmethod
-    def get_private(
+    def get(
         cls,
         session: Session,
         name: Optional[str] = None,
@@ -212,7 +218,7 @@ class Watchlist(TastytradeJsonDataclass):
         return [cls(**i) for i in data["items"]]
 
     @classmethod
-    async def a_remove_private(cls, session: Session, name: str) -> None:
+    async def a_remove(cls, session: Session, name: str) -> None:
         """
         Deletes the named private watchlist.
 
@@ -222,7 +228,7 @@ class Watchlist(TastytradeJsonDataclass):
         await session._a_delete(f"/watchlists/{name}")
 
     @classmethod
-    def remove_private(cls, session: Session, name: str) -> None:
+    def remove(cls, session: Session, name: str) -> None:
         """
         Deletes the named private watchlist.
 
@@ -231,7 +237,7 @@ class Watchlist(TastytradeJsonDataclass):
         """
         session._delete(f"/watchlists/{name}")
 
-    async def a_upload_private(self, session: Session) -> None:
+    async def a_upload(self, session: Session) -> None:
         """
         Creates a private remote watchlist identical to this local one.
 
@@ -239,7 +245,7 @@ class Watchlist(TastytradeJsonDataclass):
         """
         await session._a_post("/watchlists", json=self.model_dump(by_alias=True))
 
-    def upload_private(self, session: Session) -> None:
+    def upload(self, session: Session) -> None:
         """
         Creates a private remote watchlist identical to this local one.
 
@@ -247,7 +253,7 @@ class Watchlist(TastytradeJsonDataclass):
         """
         session._post("/watchlists", json=self.model_dump(by_alias=True))
 
-    async def a_update_private(self, session: Session) -> None:
+    async def a_update(self, session: Session) -> None:
         """
         Updates the existing private remote watchlist.
 
@@ -257,7 +263,7 @@ class Watchlist(TastytradeJsonDataclass):
             f"/watchlists/{self.name}", json=self.model_dump(by_alias=True)
         )
 
-    def update_private(self, session: Session) -> None:
+    def update(self, session: Session) -> None:
         """
         Updates the existing private remote watchlist.
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -26,7 +26,7 @@ def account_number() -> str:
 
 @fixture(scope="module")
 async def account(session: Session, account_number: str, aiolib: str) -> Account:
-    return Account.get_account(session, account_number)
+    return Account.get(session, account_number)
 
 
 def test_get_account(account: Account):
@@ -34,7 +34,7 @@ def test_get_account(account: Account):
 
 
 def test_get_accounts(session: Session):
-    assert Account.get_accounts(session) != []
+    assert Account.get(session) != []
 
 
 def test_get_trading_status(session: Session, account: Account):
@@ -90,11 +90,11 @@ def test_get_live_orders(session: Session, account: Account):
 
 
 async def test_get_account_async(session: Session, account_number: str):
-    await Account.a_get_account(session, account_number)
+    await Account.a_get(session, account_number)
 
 
 async def test_get_accounts_async(session: Session):
-    accounts = await Account.a_get_accounts(session)
+    accounts = await Account.a_get(session)
     assert accounts != []
 
 
@@ -170,7 +170,7 @@ async def test_get_order_chains_async(session: Session, account: Account):
 
 @fixture(scope="module")
 def new_order(session: Session) -> NewOrder:
-    symbol = Equity.get_equity(session, "F")
+    symbol = Equity.get(session, "F")
     leg = symbol.build_leg(Decimal(1), OrderAction.BUY_TO_OPEN)
     return NewOrder(
         time_in_force=OrderTimeInForce.DAY,
@@ -182,7 +182,7 @@ def new_order(session: Session) -> NewOrder:
 
 @fixture(scope="module")
 def notional_order(session: Session) -> NewOrder:
-    symbol = Equity.get_equity(session, "AAPL")
+    symbol = Equity.get(session, "AAPL")
     leg = symbol.build_leg(None, OrderAction.BUY_TO_OPEN)
     return NewOrder(
         time_in_force=OrderTimeInForce.DAY,
@@ -226,7 +226,7 @@ def test_replace_and_delete_order(
 
 def test_place_oco_order(session: Session, account: Account):
     # account must have a share of F for this to work
-    symbol = Equity.get_equity(session, "F")
+    symbol = Equity.get(session, "F")
     closing = symbol.build_leg(Decimal(1), OrderAction.SELL_TO_CLOSE)
     oco = NewComplexOrder(
         orders=[
@@ -252,7 +252,7 @@ def test_place_oco_order(session: Session, account: Account):
 
 
 def test_place_otoco_order(session: Session, account: Account):
-    symbol = Equity.get_equity(session, "AAPL")
+    symbol = Equity.get(session, "AAPL")
     opening = symbol.build_leg(Decimal(1), OrderAction.BUY_TO_OPEN)
     closing = symbol.build_leg(Decimal(1), OrderAction.SELL_TO_CLOSE)
     otoco = NewComplexOrder(
@@ -324,7 +324,7 @@ async def test_replace_and_delete_order_async(
 
 async def test_place_complex_order_async(session: Session, account: Account):
     sleep(3)
-    symbol = Equity.get_equity(session, "AAPL")
+    symbol = Equity.get(session, "AAPL")
     opening = symbol.build_leg(Decimal(1), OrderAction.BUY_TO_OPEN)
     closing = symbol.build_leg(Decimal(1), OrderAction.SELL_TO_CLOSE)
     otoco = NewComplexOrder(

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -20,19 +20,19 @@ from tastytrade.instruments import (
 
 
 async def test_get_cryptocurrency_async(session: Session):
-    await Cryptocurrency.a_get_cryptocurrency(session, "ETH/USD")
+    await Cryptocurrency.a_get(session, "ETH/USD")
 
 
 def test_get_cryptocurrency(session: Session):
-    Cryptocurrency.get_cryptocurrency(session, "ETH/USD")
+    Cryptocurrency.get(session, "ETH/USD")
 
 
 async def test_get_cryptocurrencies_async(session: Session):
-    await Cryptocurrency.a_get_cryptocurrencies(session)
+    await Cryptocurrency.a_get(session)
 
 
 def test_get_cryptocurrencies(session: Session):
-    Cryptocurrency.get_cryptocurrencies(session)
+    Cryptocurrency.get(session)
 
 
 async def test_get_active_equities_async(session: Session):
@@ -44,71 +44,71 @@ def test_get_active_equities(session: Session):
 
 
 async def test_get_equities_async(session: Session):
-    await Equity.a_get_equities(session, ["AAPL", "SPY"])
+    await Equity.a_get(session, ["AAPL", "SPY"])
 
 
 def test_get_equities(session: Session):
-    Equity.get_equities(session, ["AAPL", "SPY"])
+    Equity.get(session, ["AAPL", "SPY"])
 
 
 async def test_get_equity_async(session: Session):
-    await Equity.a_get_equity(session, "AAPL")
+    await Equity.a_get(session, "AAPL")
 
 
 def test_get_equity(session: Session):
-    Equity.get_equity(session, "AAPL")
+    Equity.get(session, "AAPL")
 
 
 async def test_get_futures_async(session: Session):
-    futures = await Future.a_get_futures(session, product_codes=["ES"])
+    futures = await Future.a_get(session, product_codes=["ES"])
     assert futures != []
-    await Future.a_get_future(session, futures[0].symbol)
+    await Future.a_get(session, futures[0].symbol)
 
 
 def test_get_futures(session: Session):
-    futures = Future.get_futures(session, product_codes=["ES"])
+    futures = Future.get(session, product_codes=["ES"])
     assert futures != []
-    Future.get_future(session, futures[0].symbol)
+    Future.get(session, futures[0].symbol)
 
 
 async def test_get_future_product_async(session: Session):
-    await FutureProduct.a_get_future_product(session, "ZN")
+    await FutureProduct.a_get(session, "ZN")
 
 
 def test_get_future_product(session: Session):
-    FutureProduct.get_future_product(session, "ZN")
+    FutureProduct.get(session, "ZN")
 
 
 async def test_get_future_option_product_async(session: Session):
-    await FutureOptionProduct.a_get_future_option_product(session, "LO")
+    await FutureOptionProduct.a_get(session, "LO")
 
 
 def test_get_future_option_product(session: Session):
-    FutureOptionProduct.get_future_option_product(session, "LO")
+    FutureOptionProduct.get(session, "LO")
 
 
 async def test_get_future_option_products_async(session: Session):
-    await FutureOptionProduct.a_get_future_option_products(session)
+    await FutureOptionProduct.a_get(session)
 
 
 def test_get_future_option_products(session: Session):
-    FutureOptionProduct.get_future_option_products(session)
+    FutureOptionProduct.get(session)
 
 
 async def test_get_future_products_async(session: Session):
-    await FutureProduct.a_get_future_products(session)
+    await FutureProduct.a_get(session)
 
 
 def test_get_future_products(session: Session):
-    FutureProduct.get_future_products(session)
+    FutureProduct.get(session)
 
 
 async def test_get_nested_option_chain_async(session: Session):
-    await NestedOptionChain.a_get_chain(session, "SPY")
+    await NestedOptionChain.a_get(session, "SPY")
 
 
 def test_get_nested_option_chain(session: Session):
-    NestedOptionChain.get_chain(session, "SPY")
+    NestedOptionChain.get(session, "SPY")
 
 
 async def test_get_nested_future_option_chain_async(session: Session):
@@ -120,19 +120,19 @@ def test_get_nested_future_option_chain(session: Session):
 
 
 async def test_get_warrants_async(session: Session):
-    await Warrant.a_get_warrants(session)
+    await Warrant.a_get(session)
 
 
 def test_get_warrants(session: Session):
-    Warrant.get_warrants(session)
+    Warrant.get(session)
 
 
 async def test_get_warrant_async(session: Session):
-    await Warrant.a_get_warrant(session, "NKLAW")
+    await Warrant.a_get(session, "NKLAW")
 
 
 def test_get_warrant(session: Session):
-    Warrant.get_warrant(session, "NKLAW")
+    Warrant.get(session, "NKLAW")
 
 
 async def test_get_quantity_decimal_precisions_async(session: Session):
@@ -147,7 +147,7 @@ async def test_get_option_chain_async(session: Session):
     chain = await a_get_option_chain(session, "SPY")
     assert chain != {}
     for options in chain.values():
-        await Option.a_get_option(session, options[0].symbol)
+        await Option.a_get(session, options[0].symbol)
         break
 
 
@@ -155,7 +155,7 @@ def test_get_option_chain(session: Session):
     chain = get_option_chain(session, "SPY")
     assert chain != {}
     for options in chain.values():
-        Option.get_option(session, options[0].symbol)
+        Option.get(session, options[0].symbol)
         break
 
 
@@ -163,9 +163,9 @@ async def test_get_future_option_chain_async(session: Session):
     chain = await a_get_future_option_chain(session, "ES")
     assert chain != {}
     for options in chain.values():
-        await FutureOption.a_get_future_option(session, options[0].symbol)
+        await FutureOption.a_get(session, options[0].symbol)
         symbols = [o.symbol for o in options[:4]]
-        await FutureOption.a_get_future_options(session, symbols)
+        await FutureOption.a_get(session, symbols)
         break
 
 
@@ -173,9 +173,9 @@ def test_get_future_option_chain(session: Session):
     chain = get_future_option_chain(session, "ES")
     assert chain != {}
     for options in chain.values():
-        FutureOption.get_future_option(session, options[0].symbol)
+        FutureOption.get(session, options[0].symbol)
         symbols = [o.symbol for o in options[:4]]
-        FutureOption.get_future_options(session, symbols)
+        FutureOption.get(session, symbols)
         break
 
 

--- a/tests/test_watchlists.py
+++ b/tests/test_watchlists.py
@@ -4,7 +4,7 @@ from pytest import fixture
 
 from tastytrade import Session
 from tastytrade.instruments import InstrumentType
-from tastytrade.watchlists import PairsWatchlist, Watchlist
+from tastytrade.watchlists import PairsWatchlist, PrivateWatchlist, PublicWatchlist
 
 WATCHLIST_NAME = "TestWatchlist"
 
@@ -26,72 +26,84 @@ async def test_get_pairs_watchlist_async(session: Session):
 
 
 def test_get_public_watchlists(session: Session):
-    Watchlist.get_public(session)
+    res = PublicWatchlist.get(session)
+    assert isinstance(res, list)
 
 
 def test_get_public_watchlist(session: Session):
-    Watchlist.get_public(session, "Crypto")
+    res = PublicWatchlist.get(session, "Crypto")
+    assert isinstance(res, PublicWatchlist)
 
 
 def test_get_private_watchlists(session: Session):
-    Watchlist.get_private(session)
+    res = PrivateWatchlist.get(session)
+    assert isinstance(res, list)
 
 
 async def test_get_public_watchlists_async(session: Session):
-    await Watchlist.a_get_public(session)
+    res = await PublicWatchlist.a_get(session)
+    assert isinstance(res, list)
 
 
 async def test_get_public_watchlist_async(session: Session):
-    await Watchlist.a_get_public(session, "Crypto")
+    res = await PublicWatchlist.a_get(session, "Crypto")
+    assert isinstance(res, PublicWatchlist)
 
 
 async def test_get_private_watchlists_async(session: Session):
-    await Watchlist.a_get_private(session)
+    res = await PrivateWatchlist.a_get(session)
+    assert isinstance(res, list)
 
 
 @fixture(scope="module")
-def private_wl() -> Watchlist:
-    wl = Watchlist(name=WATCHLIST_NAME)
+def private_wl() -> PrivateWatchlist:
+    wl = PrivateWatchlist(name=WATCHLIST_NAME)
     wl.add_symbol("MSFT", InstrumentType.EQUITY)
     wl.add_symbol("AAPL", InstrumentType.EQUITY)
     return wl
 
 
-def test_upload_private_watchlist(session: Session, private_wl: Watchlist):
-    private_wl.upload_private(session)
+def test_upload_private_watchlist(session: Session, private_wl: PrivateWatchlist):
+    private_wl.upload(session)
 
 
 def test_get_private_watchlist(session: Session):
     sleep(1)
-    Watchlist.get_private(session, WATCHLIST_NAME)
+    res = PrivateWatchlist.get(session, WATCHLIST_NAME)
+    assert isinstance(res, PrivateWatchlist)
 
 
-def test_update_private_watchlist(session: Session, private_wl: Watchlist):
+def test_update_private_watchlist(session: Session, private_wl: PrivateWatchlist):
     private_wl.remove_symbol("AAPL", InstrumentType.EQUITY)
     sleep(1)
-    private_wl.update_private(session)
+    private_wl.update(session)
 
 
 def test_remove_private_watchlist(session: Session):
     sleep(1)
-    Watchlist.remove_private(session, WATCHLIST_NAME)
+    PrivateWatchlist.remove(session, WATCHLIST_NAME)
 
 
-async def test_upload_private_watchlist_async(session: Session, private_wl: Watchlist):
-    await private_wl.a_upload_private(session)
+async def test_upload_private_watchlist_async(
+    session: Session, private_wl: PrivateWatchlist
+):
+    await private_wl.a_upload(session)
 
 
 async def test_get_private_watchlist_async(session: Session):
     sleep(1)
-    await Watchlist.a_get_private(session, WATCHLIST_NAME)
+    res = await PrivateWatchlist.a_get(session, WATCHLIST_NAME)
+    assert isinstance(res, PrivateWatchlist)
 
 
-async def test_update_private_watchlist_async(session: Session, private_wl: Watchlist):
+async def test_update_private_watchlist_async(
+    session: Session, private_wl: PrivateWatchlist
+):
     private_wl.remove_symbol("MSFT", InstrumentType.EQUITY)
     sleep(1)
-    await private_wl.a_update_private(session)
+    await private_wl.a_update(session)
 
 
 async def test_remove_private_watchlist_async(session: Session):
     sleep(1)
-    await Watchlist.a_remove_private(session, WATCHLIST_NAME)
+    await PrivateWatchlist.a_remove(session, WATCHLIST_NAME)

--- a/tests/test_watchlists.py
+++ b/tests/test_watchlists.py
@@ -10,43 +10,43 @@ WATCHLIST_NAME = "TestWatchlist"
 
 
 def test_get_pairs_watchlists(session: Session):
-    PairsWatchlist.get_pairs_watchlists(session)
+    PairsWatchlist.get(session)
 
 
 def test_get_pairs_watchlist(session: Session):
-    PairsWatchlist.get_pairs_watchlist(session, "Stocks")
+    PairsWatchlist.get(session, "Stocks")
 
 
 async def test_get_pairs_watchlists_async(session: Session):
-    await PairsWatchlist.a_get_pairs_watchlists(session)
+    await PairsWatchlist.a_get(session)
 
 
 async def test_get_pairs_watchlist_async(session: Session):
-    await PairsWatchlist.a_get_pairs_watchlist(session, "Stocks")
+    await PairsWatchlist.a_get(session, "Stocks")
 
 
 def test_get_public_watchlists(session: Session):
-    Watchlist.get_public_watchlists(session)
+    Watchlist.get_public(session)
 
 
 def test_get_public_watchlist(session: Session):
-    Watchlist.get_public_watchlist(session, "Crypto")
+    Watchlist.get_public(session, "Crypto")
 
 
 def test_get_private_watchlists(session: Session):
-    Watchlist.get_private_watchlists(session)
+    Watchlist.get_private(session)
 
 
 async def test_get_public_watchlists_async(session: Session):
-    await Watchlist.a_get_public_watchlists(session)
+    await Watchlist.a_get_public(session)
 
 
 async def test_get_public_watchlist_async(session: Session):
-    await Watchlist.a_get_public_watchlist(session, "Crypto")
+    await Watchlist.a_get_public(session, "Crypto")
 
 
 async def test_get_private_watchlists_async(session: Session):
-    await Watchlist.a_get_private_watchlists(session)
+    await Watchlist.a_get_private(session)
 
 
 @fixture(scope="module")
@@ -58,40 +58,40 @@ def private_wl() -> Watchlist:
 
 
 def test_upload_private_watchlist(session: Session, private_wl: Watchlist):
-    private_wl.upload_private_watchlist(session)
+    private_wl.upload_private(session)
 
 
 def test_get_private_watchlist(session: Session):
     sleep(1)
-    Watchlist.get_private_watchlist(session, WATCHLIST_NAME)
+    Watchlist.get_private(session, WATCHLIST_NAME)
 
 
 def test_update_private_watchlist(session: Session, private_wl: Watchlist):
     private_wl.remove_symbol("AAPL", InstrumentType.EQUITY)
     sleep(1)
-    private_wl.update_private_watchlist(session)
+    private_wl.update_private(session)
 
 
 def test_remove_private_watchlist(session: Session):
     sleep(1)
-    Watchlist.remove_private_watchlist(session, WATCHLIST_NAME)
+    Watchlist.remove_private(session, WATCHLIST_NAME)
 
 
 async def test_upload_private_watchlist_async(session: Session, private_wl: Watchlist):
-    await private_wl.a_upload_private_watchlist(session)
+    await private_wl.a_upload_private(session)
 
 
 async def test_get_private_watchlist_async(session: Session):
     sleep(1)
-    await Watchlist.a_get_private_watchlist(session, WATCHLIST_NAME)
+    await Watchlist.a_get_private(session, WATCHLIST_NAME)
 
 
 async def test_update_private_watchlist_async(session: Session, private_wl: Watchlist):
     private_wl.remove_symbol("MSFT", InstrumentType.EQUITY)
     sleep(1)
-    await private_wl.a_update_private_watchlist(session)
+    await private_wl.a_update_private(session)
 
 
 async def test_remove_private_watchlist_async(session: Session):
     sleep(1)
-    await Watchlist.a_remove_private_watchlist(session, WATCHLIST_NAME)
+    await Watchlist.a_remove_private(session, WATCHLIST_NAME)


### PR DESCRIPTION
## Description
This PR changes SDK naming conventions around Pydantic models to be less verbose:

`tastytrade<10` version:
```python
from tastytrade import Account
accounts = Account.get_accounts(session)
account = Account.get_account(session, "5WQ01234")
```

`tastytrade>=10` version:
```python
from tastytrade import Account
accounts = Account.get(session)
account = Account.get(session, "5WQ01234")
```

Here, `get_accounts` and `get_account` are rolled into a single `get` method. This preserves type hints thanks to `typing.overload`, where the return type will be inferred from the number of arguments.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [x] New tests added (if applicable)
- [x] Split `Watchlist` class into `PublicWatchlist` and `PrivateWatchlist`
- [x] Update docs

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.