### PR TITLE
Creating the get_market_data function

### DIFF
--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -1451,3 +1451,36 @@ def get_future_option_chain(
         chain[option.expiration_date].append(option)
 
     return chain
+
+def get_market_data(
+    session: Session, requests: dict
+):
+    """
+    Returns a list of dictionaries containing a symbol and its associated market data.
+
+    Example request to endpoint:
+    https://api.tastyworks.com/market-data/by-type?equity=AAPL&equity-option=AAPL%20%20250620C00180000&equity=MSFT&equity-option=MSFT%20%20250620C00355000&future=%2FESM5&cryptocurrency=BTC%2FUSD&future-option=.%2FESM5%20EW2M5%20250613C4600\
+
+    :param session: the session to use for the request.
+    :param requests: the dictionary of requested security types to a list of the
+    securities of that type you want the market data for. The combined limit of
+    all tickers requested at once is 100.
+
+    Valid values for requests keys:
+    "index", "equity", "equity-option", "future", "future-option", "cryptocurrency"
+    """
+    parts = []
+    for key, values in requests.items():
+        for v in values:
+            parts.append(f"{key.lower()}={str(v)}")
+
+    symbol = "&".join(parts)
+
+    symbol = symbol.replace("/", "%2F")
+    symbol = symbol.replace(" ", "%20")
+    data = session._get(f"/market-data/by-type?{symbol}")
+    if 'items' in data:
+        market_data = data["items"]
+    else:
+        market_data = []
+    return market_data

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -178,6 +178,14 @@ def test_get_future_option_chain(session: Session):
         FutureOption.get(session, symbols)
         break
 
+def test_get_market_data(session: Session):
+    requests = {
+        "equity": ["AAPL", "MSFT"],
+        "future": ["/ES", "/VX"],
+        "equity-option": ["AAPL  250620C00180000"],
+        "future-option": ["./ESM5 EW2M5 250613C4600"]
+    } # use some options that exist
+    get_market_data(session, requests)
 
 def test_streamer_symbol_to_occ():
     dxf = ".SPY240324P480.5"


### PR DESCRIPTION
## Description
This creates the get_market_data function which uses the market-data/by-type endpoint. This endpoint can be used to quickly get a snapshot of price and instrument data without having to use the streamer.
## Related issue(s)

## Pre-merge checklist
- [ ] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [x] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
