### PR TITLE
Catch the WebSocket ConnectionClosedError

### DIFF
--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -19,7 +19,7 @@ from typing import (
 
 from pydantic import model_validator
 from websockets.asyncio.client import ClientConnection, connect
-from websockets.exceptions import ConnectionClosed
+from websockets.exceptions import ConnectionClosed, ConnectionClosedError
 
 from tastytrade import logger, version_str
 from tastytrade.account import Account, AccountBalance, CurrentPosition, TradingStatus
@@ -614,6 +614,9 @@ class DXLinkStreamer:
                 await asyncio.sleep(30)
         except asyncio.CancelledError:
             logger.debug("Websocket interrupted, cancelling heartbeat.")
+            return
+        except ConnectionClosedError as closed_error:
+            logger.debug(f"WebSocket closed. Reason: {closed_error.reason}")
             return
 
     async def subscribe(


### PR DESCRIPTION
## Description
This fix catches the WebSocket Exception ConnectionClosedError during trying to send the heartbeat. This exception occurs when the network connection beaks for a couple of minutes and then reconnection process is performed.

## Related issue(s)
Belongs to issue #229 

## Pre-merge checklist
- [X] Code formatted correctly (check with `make lint`)
- [X] Code implemented for both sync and async
- [X] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
