### PR TITLE
fix oauth refresh bug

### DIFF
--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,7 +4,7 @@ API_URL = "https://api.tastyworks.com"
 BACKTEST_URL = "https://backtester.vast.tastyworks.com"
 CERT_URL = "https://api.cert.tastyworks.com"
 VAST_URL = "https://vast.tastyworks.com"
-VERSION = "10.2.2"
+VERSION = "10.2.3"
 
 __version__ = VERSION
 version_str: str = f"tastyware/tastytrade:v{VERSION}"

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -578,7 +578,8 @@ class OAuthSession(Session):  # pragma: no cover
         """
         Refreshes the acccess token using the stored refresh token.
         """
-        response = self.sync_client.post(
+        request = self.sync_client.build_request(
+            "POST",
             "/oauth/token",
             json={
                 "grant_type": "refresh_token",
@@ -586,6 +587,9 @@ class OAuthSession(Session):  # pragma: no cover
                 "refresh_token": self.refresh_token,
             },
         )
+        # Don't send the Authorization header for this request
+        request.headers.pop("Authorization", None)
+        response = self.sync_client.send(request)
         validate_response(response)
         data = response.json()
         # update the relevant tokens
@@ -602,7 +606,8 @@ class OAuthSession(Session):  # pragma: no cover
         """
         Refreshes the acccess token using the stored refresh token.
         """
-        response = await self.async_client.post(
+        request = self.async_client.build_request(
+            "POST",
             "/oauth/token",
             json={
                 "grant_type": "refresh_token",
@@ -610,6 +615,9 @@ class OAuthSession(Session):  # pragma: no cover
                 "refresh_token": self.refresh_token,
             },
         )
+        # Don't send the Authorization header for this request
+        request.headers.pop("Authorization", None)
+        response = await self.async_client.send(request)
         validate_response(response)
         data = response.json()
         # update the relevant tokens

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -147,7 +147,10 @@ async def test_get_option_chain_async(session: Session):
     chain = await a_get_option_chain(session, "SPY")
     assert chain != {}
     for options in chain.values():
-        await Option.a_get(session, options[0].symbol)
+        single = await Option.a_get(session, options[0].symbol)
+        multiple = await Option.a_get(session, [options[0].symbol, options[1].symbol])
+        assert isinstance(single, Option)
+        assert isinstance(multiple, list)
         break
 
 
@@ -155,7 +158,14 @@ def test_get_option_chain(session: Session):
     chain = get_option_chain(session, "SPY")
     assert chain != {}
     for options in chain.values():
-        Option.get(session, options[0].symbol)
+        single = Option.get(session, options[0].symbol)
+        # test setting symbol
+        old = single.streamer_symbol
+        single._set_streamer_symbol()
+        assert single.streamer_symbol == old
+        multiple = Option.get(session, [options[0].symbol, options[1].symbol])
+        assert isinstance(single, Option)
+        assert isinstance(multiple, list)
         break
 
 


### PR DESCRIPTION
## Description
Fixes a bug where `refresh` and `a_refresh` calls subsequent to the first in `OAuthSession` would fail due to an extra, illegal header.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_USERNAME`, `TT_PASSWORD`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
