### PR TITLE
Make closing_only_date optional in Future class

### DIFF
--- a/tastytrade/instruments.py
+++ b/tastytrade/instruments.py
@@ -869,7 +869,7 @@ class Future(TradeableTastytradeData):
     display_factor: Decimal
     last_trade_date: date
     expiration_date: date
-    closing_only_date: date
+    closing_only_date: Optional[date] = None
     active: bool
     active_month: bool
     next_active_month: bool


### PR DESCRIPTION
## Summary
Fixes a Pydantic validation error when fetching certain futures contracts that don't include the `closing-only-date` field in API responses.

## Problem
When attempting to load instrument data for futures contracts like `/1OZZ5` (1oz gold futures) using `Future.get()`, the SDK raises a Pydantic validation error because the API response is missing the required `closing-only-date` field.

## Solution
Changed the `closing_only_date` field in the `Future` class from a required field to an optional field with a default value of `None`.

## Changes
- Modified `tastytrade/instruments.py` line 872: `closing_only_date: date` → `closing_only_date: Optional[date] = None`

## Testing
- Ran `make lint` - All checks passed ✓
- Ran `make test` - 126 tests passed, 96.46% coverage (exceeds 95% requirement) ✓
- No new test failures introduced
- Baseline test failures remain unchanged (unrelated to this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)