### PR TITLE
Type correction in PlacedOrder

### DIFF
--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -317,7 +317,7 @@ class PlacedOrder(TastytradeData):
     cancel_user_id: str | None = None
     cancel_username: str | None = None
     replacing_order_id: str | None = None
-    replaces_order_id: str | None = None
+    replaces_order_id: int | None = None
     in_flight_at: datetime | None = None
     live_at: datetime | None = None
     received_at: datetime | None = None


### PR DESCRIPTION
## Description
The type of attribute replaces_order_id in PlacedOrder has been changed from str to int.

With that fix replacement of orders is working again now.

Maybe the attribute `replacing_order_id` should be changed as well, but in my case it had no value. I assume it is there for compatibility reasons only.

## Related issue(s)
Fixes #285 

## Pre-merge checklist
- [X] Code formatted correctly (check with `make lint`)
- [X] Code implemented for both sync and async
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
