### PR TITLE
added check if market is open at this moment in utils 

### DIFF
--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -51,14 +51,22 @@ def is_market_open_now() -> bool:
     Returns True if:
     - The market is open on the current date (not a holiday/weekend)
     - The current Eastern Time hour is between [ 9:30 AM, 4:00 PM )
+    - or on half days between [ 9:30 AM, 1:00 PM )
 
     Returns:
         bool: True if market is open now, False otherwise
     """
-    now_est = datetime.now(TZ)
-    return is_market_open_on(now_est.date()) and (
-        (now_est.hour == 9 and now_est.minute >= 30) or 10 <= now_est.hour < 16
-    )
+    today = today_in_new_york()
+    sched = NYSE.schedule(start_date=today, end_date=today)
+    if sched.empty:
+        # Closed full day (weekend or holiday)
+        return False
+
+    # Use iloc[0] since schedule has only one row for a single day
+    market_open = sched.iloc[0]["market_open"]
+    market_close = sched.iloc[0]["market_close"]
+
+    return market_open <= now_in_new_york() < market_close
 
 
 def is_market_open_on(day: date | None = None) -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -208,3 +208,23 @@ def test_is_market_open_now():
     with patch("tastytrade.utils.datetime") as mock_datetime:
         mock_datetime.now.return_value = datetime(2024, 3, 12, 15, 59, 0, tzinfo=TZ)
         assert is_market_open_now() is True
+
+    # Test edge case: Black Friday just before market open
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 9, 29, 0, tzinfo=TZ)
+        assert is_market_open_now() is False
+
+    # Test edge case: Black Friday just after market open
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 9, 30, 0, tzinfo=TZ)
+        assert is_market_open_now() is True
+
+    # Test edge case: Black Friday just before market close half day
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 12, 59, 0, tzinfo=TZ)
+        assert is_market_open_now() is True
+
+    # Test edge case: Black Friday just after market close half day
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 13, 0, 0, tzinfo=TZ)
+        assert is_market_open_now() is False


### PR DESCRIPTION
## Description

## Related issue(s)
Added a util not a fix

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [-] Code implemented for both sync and async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set)
-- Only tested the added util. Very simple code, shouldn't break anything. tastytrade.utils completely tested including new fucntion
- [x] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
