### PR TITLE
Add external_identifier field to NewOrder and PlacedOrder classes

### DIFF
--- a/tastytrade/order.py
+++ b/tastytrade/order.py
@@ -254,6 +254,8 @@ class NewOrder(TastytradeData):
     preflight_id: str | None = None
     rules: OrderRule | None = None
     advanced_instructions: AdvancedInstructions | None = None
+    #: External identifier for the order, used to track orders across systems
+    external_identifier: str | None = None
 
     @computed_field  # type: ignore[misc]
     @property
@@ -330,6 +332,8 @@ class PlacedOrder(TastytradeData):
     preflight_id: str | int | None = None
     order_rule: OrderRule | None = None
     source: str | None = None
+    #: External identifier for the order, used to track orders across systems
+    external_identifier: str | None = None
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
This update introduces an external_identifier attribute to both NewOrder and PlacedOrder classes, allowing for better tracking of orders across systems.

## Description

## Related issue(s)
Fixes ...

## Pre-merge checklist
- [ ] Code formatted correctly (check with `make lint`)
- [ ] Code implemented for both sync and async
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
