### PR TITLE
Added event streamer featuring a callback to handle received events.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/examples/event_streamer.py
+++ b/examples/event_streamer.py
@@ -1,0 +1,199 @@
+"""
+Example usage of the EventStreamer class
+
+NOTE: quick and dirty implementation
+"""
+
+import asyncio
+import os
+from datetime import datetime
+from decimal import Decimal
+from typing import TypeVar
+
+import dotenv
+
+from tastytrade.dxfeed import (
+    Candle,
+    Greeks,
+    Profile,
+    Quote,
+    Summary,
+    TheoPrice,
+    TimeAndSale,
+    Trade,
+    Underlying,
+)
+from tastytrade.session import Session
+from tastytrade.streamer import EventStreamer
+
+dotenv.load_dotenv()
+
+session = Session(
+    provider_secret=os.getenv("TT_API_CLIENT_SECRET", ""),
+    refresh_token=os.getenv("TT_REFRESH_TOKEN", ""),
+)
+
+
+E = TypeVar(
+    "E",
+    Candle,
+    Greeks,
+    Profile,
+    Quote,
+    Summary,
+    TheoPrice,
+    TimeAndSale,
+    Trade,
+    Underlying,
+)
+
+
+class OHLCVBar:
+    def __init__(self, open_price: Decimal, volume: int | None, timestamp: datetime):
+        self.open: Decimal = open_price
+        self.high: Decimal = open_price
+        self.low: Decimal = open_price
+        self.close: Decimal = open_price
+        self.volume: int | None = volume
+        self.tick_count: int = 1
+        self.timestamp: datetime = timestamp
+
+    def update(self, price: Decimal, volume: int | None) -> None:
+        self.high = max(self.high, price)
+        self.low = min(self.low, price)
+        self.close = price
+        self.volume = volume if volume is not None else self.volume
+        self.tick_count += 1
+
+    def __str__(self) -> str:
+        return (
+            f"OHLCVBar(open={self.open}, high={self.high}, low={self.low},"
+            f" close={self.close}, volume={self.volume}, "
+            f"tick_count={self.tick_count}, timestamp={self.timestamp})"
+        )
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class OHLCVBars:
+    def __init__(self, timeframe: str):
+        self.ohlcv_bars: list[OHLCVBar] = []
+        self.current_bar: OHLCVBar | None = None
+        self.timeframe: str = timeframe
+
+    def update(self, event: Trade) -> None:
+        ts_ms = event.time
+
+        # --- TICK BARS ---
+        if self.timeframe.endswith("t"):
+            n = int(self.timeframe[:-1])  # "200t" -> 200 (also works for "1t")
+
+            if self.current_bar is None:
+                self.current_bar = OHLCVBar(event.price, event.size, timestamp=datetime.fromtimestamp(ts_ms / 1000))
+            else:
+                self.current_bar.update(event.price, event.size)
+
+            # close AFTER update so tick_count includes this trade
+            if self.current_bar.tick_count >= n:
+                self.ohlcv_bars.append(self.current_bar)
+                # start a new bar on next tick (or immediately if you prefer)
+                self.current_bar = None
+                print(self.ohlcv_bars[-1])
+            return
+
+        # --- TIME BARS (bucketed) ---
+        bucket_ts = self.bucket_timestamp(ts_ms, self.timeframe)
+        if self.current_bar is not None:
+            print(ts_ms, bucket_ts, self.current_bar.timestamp)
+
+        if self.current_bar is None:
+            self.current_bar = OHLCVBar(
+                event.price, event.size, timestamp=bucket_ts
+            )
+            return
+
+        # If this tick belongs to a new time bucket, finalize old bar and start new one
+        if bucket_ts != self.current_bar.timestamp:
+            self.ohlcv_bars.append(self.current_bar)
+            self.current_bar = OHLCVBar(
+                event.price, event.size, timestamp=bucket_ts
+            )
+            print(self.ohlcv_bars[-1])
+        else:
+            self.current_bar.update(event.price, event.size)
+
+    @staticmethod
+    def bucket_timestamp(ts_ms: int, timeframe: str) -> datetime:
+        # floor ts into the timeframe bucket so you never get two candles for the
+        # same bucket
+        if timeframe == "5s":
+            start = (ts_ms // 5_000) * 5_000
+        elif timeframe == "1m":
+            start = (ts_ms // 60_000) * 60_000
+        elif timeframe == "5m":
+            start = (ts_ms // 300_000) * 300_000
+        elif timeframe == "15m":
+            start = (ts_ms // 900_000) * 900_000
+        elif timeframe == "30m":
+            start = (ts_ms // 1_800_000) * 1_800_000
+        elif timeframe == "1h":
+            start = (ts_ms // 3_600_000) * 3_600_000
+        elif timeframe == "4h":
+            start = (ts_ms // 14_400_000) * 14_400_000
+        elif timeframe == "1d":
+            start = (ts_ms // 86_400_000) * 86_400_000
+        elif timeframe == "1w":
+            start = (ts_ms // 604_800_000) * 604_800_000
+        else:
+            raise ValueError(f"Invalid timeframe: {timeframe}")
+
+        return datetime.fromtimestamp(start / 1000)
+
+
+ohlcv_bars_dict: dict[str, OHLCVBars] = {}
+
+
+def ohlcv_bars(symbols: list[str]) -> None:
+    global ohlcv_bars_list
+    for symbol in symbols:
+        ohlcv_bars_dict[symbol] = OHLCVBars("1m")
+
+
+async def update_ohlcv_bars(trade: Trade) -> None:
+    global ohlcv_bars_dict
+    ohlcv_bars_dict[trade.event_symbol].update(trade)
+
+
+async def handle_quote(quote: Quote) -> None:
+    print(quote)
+
+
+async def monitor_streamer(event_streamer: EventStreamer, stop_time: int) -> None:
+    """
+    Monitor the streamer and stop it after the given time
+
+    NOTE: stop() will only stop after listen has returned with an event
+    """
+
+    await asyncio.sleep(stop_time)
+    event_streamer.stop()
+
+
+async def main() -> None:
+    # ohlcv_bars = OHLCVBars(symbols=["SPY", "AAPL"], timeframe="1t")
+    quote_streamer = EventStreamer(session, ["SPY"], Quote, handle_quote)
+    symbols = ["SPY", "AAPL"]
+    ohlcv_bars(symbols=symbols)  # initialize the ohlcv bars in a global dictionary
+
+    ohlcv_bars_streamers = [EventStreamer(session, [symbol], Trade, update_ohlcv_bars) for symbol in symbols]
+    await asyncio.gather(
+        quote_streamer.start(),
+        monitor_streamer(quote_streamer, 10),
+        *(streamer.start() for streamer in ohlcv_bars_streamers),
+        *(monitor_streamer(streamer, 120) for streamer in ohlcv_bars_streamers)
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "httpx>=0.28.1",
     "pandas-market-calendars>=5.1.1",
     "pydantic>=2.11.9",
+    "python-dotenv>=1.0.0",
     "websockets>=15.0.1",
 ]
 dynamic = ["version"]

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -884,3 +884,70 @@ class DXLinkStreamer:
             results = cls.from_stream(data)
             for r in results:
                 await self._queues[msg_type].put(r)  # type: ignore
+
+
+class EventStreamer:
+    """
+    Utility class to streamline the process of subscribing to events and
+    calling a callback when an event is received.
+
+    NOTE: Instantiate an instance of EventStreamer for each event class
+          you want to stream
+
+    NOTE: if you need to be able to stop the streamer,
+          you can create a separate coroutine with access
+          to the EventSteamer object and call the stop() method on it
+
+    NOTE: stop() will only stop after listen has returned with an event
+    """
+
+    def __init__(
+        self,
+        session: Session,
+        symbols: list[str],
+        event_class: type[U],
+        callback: Callable[[U], Coroutine[Any, Any, None]],
+    ):
+        """
+        Initializes the event streamer
+
+        :param session: The session to use for the streamer
+        :param symbols: The symbols to subscribe to
+        :param event_class: The event class to subscribe to
+        :param callback: The callback to call when an event is received
+        """
+
+        self._session = session
+        self._symbols = symbols
+        self._event_class = event_class
+        # callback can be set to different function by consumer after initialization
+        self.callback = callback
+        self._stop: bool = False
+
+    def stop(self) -> None:
+        """
+        Stops the event streamer
+        """
+
+        self._stop = True
+
+    async def start(self) -> None:
+        """
+        starts the streamer and subscribes to the given symbols and calls
+        the callback when an event is received
+        NOTE: This function is blocking until the stop() method is called
+        """
+
+        if self.callback is None:
+            raise TastytradeError("No callback provided")
+
+        self._stop = False
+
+        async with DXLinkStreamer(self._session) as streamer:
+            await streamer.subscribe(self._event_class, self._symbols)  # type: ignore
+            async for event in streamer.listen(self._event_class):
+                if self._stop:
+                    break
+                await self.callback(event)  # type: ignore
+
+        self._stop = False

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -894,11 +894,7 @@ class EventStreamer:
     NOTE: Instantiate an instance of EventStreamer for each event class
           you want to stream
 
-    NOTE: if you need to be able to stop the streamer,
-          you can create a separate coroutine with access
-          to the EventSteamer object and call the stop() method on it
-
-    NOTE: stop() will only stop after listen has returned with an event
+    NOTE: stop the streamer by cancelling the task
     """
 
     def __init__(
@@ -922,20 +918,11 @@ class EventStreamer:
         self._event_class = event_class
         # callback can be set to different function by consumer after initialization
         self.callback = callback
-        self._stop: bool = False
-
-    def stop(self) -> None:
-        """
-        Stops the event streamer
-        """
-
-        self._stop = True
 
     async def start(self) -> None:
         """
         starts the streamer and subscribes to the given symbols and calls
         the callback when an event is received
-        NOTE: This function is blocking until the stop() method is called
         """
 
         if self.callback is None:
@@ -946,8 +933,6 @@ class EventStreamer:
         async with DXLinkStreamer(self._session) as streamer:
             await streamer.subscribe(self._event_class, self._symbols)  # type: ignore
             async for event in streamer.listen(self._event_class):
-                if self._stop:
-                    break
                 await self.callback(event)  # type: ignore
 
         self._stop = False

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -51,14 +51,22 @@ def is_market_open_now() -> bool:
     Returns True if:
     - The market is open on the current date (not a holiday/weekend)
     - The current Eastern Time hour is between [ 9:30 AM, 4:00 PM )
+    - or on half days between [ 9:30 AM, 1:00 PM )
 
     Returns:
         bool: True if market is open now, False otherwise
     """
-    now_est = datetime.now(TZ)
-    return is_market_open_on(now_est.date()) and (
-        (now_est.hour == 9 and now_est.minute >= 30) or 10 <= now_est.hour < 16
-    )
+    today = today_in_new_york()
+    sched = NYSE.schedule(start_date=today, end_date=today)
+    if sched.empty:
+        # Closed full day (weekend or holiday)
+        return False
+
+    # Use iloc[0] since schedule has only one row for a single day
+    market_open = sched.iloc[0]["market_open"]
+    market_close = sched.iloc[0]["market_close"]
+
+    return market_open <= now_in_new_york() < market_close
 
 
 def is_market_open_on(day: date | None = None) -> bool:

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -47,21 +47,17 @@ def today_in_new_york() -> date:
 def is_market_open_now() -> bool:
     """
     Check if the market is currently open.
-    
+
     Returns True if:
     - The market is open on the current date (not a holiday/weekend)
     - The current Eastern Time hour is between [ 9:30 AM, 4:00 PM )
-    
+
     Returns:
         bool: True if market is open now, False otherwise
     """
     now_est = datetime.now(TZ)
-    return (
-        is_market_open_on(now_est.date()) and
-        (
-            (now_est.hour == 9 and now_est.minute >= 30) or
-            10 <= now_est.hour < 16
-        )
+    return is_market_open_on(now_est.date()) and (
+        (now_est.hour == 9 and now_est.minute >= 30) or 10 <= now_est.hour < 16
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -208,3 +208,23 @@ def test_is_market_open_now():
     with patch("tastytrade.utils.datetime") as mock_datetime:
         mock_datetime.now.return_value = datetime(2024, 3, 12, 15, 59, 0, tzinfo=TZ)
         assert is_market_open_now() is True
+
+    # Test edge case: Black Friday just before market open
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 9, 29, 0, tzinfo=TZ)
+        assert is_market_open_now() is False
+
+    # Test edge case: Black Friday just after market open
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 9, 30, 0, tzinfo=TZ)
+        assert is_market_open_now() is True
+
+    # Test edge case: Black Friday just before market close half day
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 12, 59, 0, tzinfo=TZ)
+        assert is_market_open_now() is True
+
+    # Test edge case: Black Friday just after market close half day
+    with patch("tastytrade.utils.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 11, 29, 13, 0, 0, tzinfo=TZ)
+        assert is_market_open_now() is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 from datetime import date, datetime
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from tastytrade.utils import (
-    TZ,
     get_future_fx_monthly,
     get_future_grain_monthly,
     get_future_index_monthly,
@@ -14,6 +14,8 @@ from tastytrade.utils import (
     is_market_open_now,
     today_in_new_york,
 )
+
+TZ = ZoneInfo("US/Eastern")
 
 
 def test_get_third_friday():
@@ -206,23 +208,3 @@ def test_is_market_open_now():
     with patch("tastytrade.utils.datetime") as mock_datetime:
         mock_datetime.now.return_value = datetime(2024, 3, 12, 15, 59, 0, tzinfo=TZ)
         assert is_market_open_now() is True
-
-    # Test edge case: Black Friday just before market open
-    with patch("tastytrade.utils.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(2024, 11, 29, 9, 29, 0, tzinfo=TZ)
-        assert is_market_open_now() is False
-
-    # Test edge case: Black Friday just after market open
-    with patch("tastytrade.utils.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(2024, 11, 29, 9, 30, 0, tzinfo=TZ)
-        assert is_market_open_now() is True
-
-    # Test edge case: Black Friday just before market close half day
-    with patch("tastytrade.utils.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(2024, 11, 29, 12, 59, 0, tzinfo=TZ)
-        assert is_market_open_now() is True
-
-    # Test edge case: Black Friday just after market close half day
-    with patch("tastytrade.utils.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(2024, 11, 29, 13, 0, 0, tzinfo=TZ)
-        assert is_market_open_now() is False

--- a/uv.lock
+++ b/uv.lock
@@ -2022,6 +2022,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pandas-market-calendars" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "websockets" },
 ]
 
@@ -2050,6 +2051,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pandas-market-calendars", specifier = ">=5.1.1" },
     { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
 


### PR DESCRIPTION
## Description
In streamer.py an event streamer has been added that instantiates a DXLinkStreamer starts listening to events of the given event type. When a new event is received a callback function is called with that event.

The reason to add this is that this function is a common pattern to work with the DXLinkStreamer and therefore deserves to be part of this SDK IMO.

Als an examples folder has been added showcasing the use of the event streamer as an application reference. This example has been used to test the implementation of the event streamer.

## Related issue(s)
None

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Code implemented for both sync and async - due to it's nature it's only async
- [x] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set) - See description to check how it has been tested
- [x] New tests added (if applicable) - NA

Please note that, in order to pass the tests, you'll need to set up your Tastytrade credentials as repository secrets on your local fork. Read more at CONTRIBUTING.md.
