### PR TITLE
session client parameters

### DIFF
--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -258,6 +258,9 @@ class Session(AsyncContextManagerMixin):
     :param proxy:
         if provided, all requests will be made through this proxy, as well as
         web socket connections for streamers.
+    :param client_kwargs:
+        additional keyword arguments, besides proxy, to pass to the httpx
+        AsyncClient, such as `timeout`
     """
 
     def __init__(
@@ -266,6 +269,7 @@ class Session(AsyncContextManagerMixin):
         refresh_token: str,
         is_test: bool = False,
         proxy: str | None = None,
+        **client_kwargs: Any,
     ):
         #: Whether this is a cert or real session
         self.is_test = is_test
@@ -285,8 +289,12 @@ class Session(AsyncContextManagerMixin):
         self.session_token = "kyrieeleison"
         # httpx client for all requests
         self._client = AsyncClient(
-            base_url=(CERT_URL if is_test else API_URL), headers=headers, proxy=proxy
+            base_url=(CERT_URL if is_test else API_URL),
+            headers=headers,
+            proxy=proxy,
+            **client_kwargs,
         )
+        self.client_kwargs = client_kwargs
         self._lock = Lock()
 
     @asynccontextmanager
@@ -312,6 +320,7 @@ class Session(AsyncContextManagerMixin):
         """
         Serializes the session to a string, useful for storing a session for later use.
         Could be used with pickle, Redis, etc.
+        Only sessions with JSON serializable client_kwargs can be serialized.
         """
         attrs = self.__dict__.copy()
         del attrs["_client"]
@@ -329,6 +338,7 @@ class Session(AsyncContextManagerMixin):
             refresh_token=deserialized["refresh_token"],
             is_test=deserialized["is_test"],
             proxy=deserialized["proxy"],
+            **deserialized.get("client_kwargs", {}),
         )
         self.session_expiration = deserialized["session_expiration"]
         self.session_token = deserialized["session_token"]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 import pytest
 from proxy import TestCase
 
@@ -6,14 +9,33 @@ from tastytrade import Session
 pytestmark = pytest.mark.anyio
 
 
+@pytest.fixture(scope="module")
+def session_with_kwargs(anyio_backend: str) -> Session:
+    return Session(os.environ["TT_SECRET"], os.environ["TT_REFRESH"], timeout=10.0)
+
+
 async def test_get_customer(session: Session):
     await session.get_customer()
 
 
-def test_serialize_deserialize(session: Session):
+def test_serialize_deserialize(session: Session, session_with_kwargs: Session):
+    # No client_kwargs
     data = session.serialize()
     obj = Session.deserialize(data)
     assert set(obj.__dict__.keys()) == set(session.__dict__.keys())
+    assert obj.client_kwargs == session.client_kwargs
+    # Simulate legacy serialized payloads that didn't include client_kwargs.
+    legacy_payload = json.loads(data)
+    del legacy_payload["client_kwargs"]
+    legacy_obj = Session.deserialize(json.dumps(legacy_payload))
+    assert legacy_obj.client_kwargs == {}
+    # With timeout client_kwargs
+    data_with_kwargs = session_with_kwargs.serialize()
+    obj_with_kwargs = Session.deserialize(data_with_kwargs)
+    assert set(obj_with_kwargs.__dict__.keys()) == set(
+        session_with_kwargs.__dict__.keys()
+    )
+    assert obj_with_kwargs.client_kwargs == session_with_kwargs.client_kwargs
 
 
 @pytest.mark.usefixtures("inject_credentials")


### PR DESCRIPTION
## Description
Added `client_kwargs` argument to `Session` constructor to be passed to the `httpx.AsyncClient`. Adjusted `Session.deserialize` to be backwards compatible with older serialized sessions without the new attribute. Left `Session.serialize` as is and it will raise if the `client_kwargs` are not serializable.
Updated tests (`test_session.py`) to simulate older sessions to insure backwards compatibility. Add a new module fixture for a session with kwargs.
In the future it might make sense to use include `proxy` in the kwargs as well, since it is a parameter intended for the client as well. That would be a breaking change though, as `proxy` is also positional.

## Related issue(s)
#310 

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set)
- [x] Tests extended
- [ ] Docs updated (if applicable)