### PR TITLE
Quotes with missing bid/ask sizes

### DIFF
--- a/tastytrade/dxfeed/event.py
+++ b/tastytrade/dxfeed/event.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+)
 from pydantic.alias_generators import to_camel
+from pydantic_core import PydanticUndefined
 
 from tastytrade.utils import TastytradeError
 
@@ -29,10 +36,13 @@ class Event(BaseModel):
 
     @field_validator("*", mode="before")
     @classmethod
-    def change_nan_to_none(cls, v: Any) -> Any:
-        if v in {"NaN", "Infinity", "-Infinity"}:
+    def change_nan_to_none(cls, v: Any, info: ValidationInfo) -> Any:
+        if v not in {"NaN", "Infinity", "-Infinity"}:
+            return v
+        if info.field_name not in cls.model_fields:
             return None
-        return v
+        field = cls.model_fields[info.field_name]
+        return field.default if field.default is not PydanticUndefined else None
 
     @classmethod
     def from_stream(cls, data: list[Any]) -> list[Self]:

--- a/tastytrade/dxfeed/quote.py
+++ b/tastytrade/dxfeed/quote.py
@@ -1,12 +1,9 @@
 from decimal import Decimal
 
-from pydantic import field_validator
-
 from .. import logger
 from .event import Event
 
 _ZERO = Decimal(0)
-_NaN = "NaN"
 
 
 class Quote(Event):
@@ -33,20 +30,10 @@ class Quote(Event):
     ask_price: Decimal
     #: bid size as integer number (rounded toward zero)
     #: or decimal for cryptocurrencies
-    bid_size: Decimal
+    bid_size: Decimal = _ZERO
     #: ask size as integer number (rounded toward zero)
     #: or decimal for cryptocurrencies
-    ask_size: Decimal
-
-    @field_validator("bid_size", "ask_size", mode="before")
-    @classmethod
-    def _coerce_missing_sizes(cls, v: Decimal | str | None) -> Decimal | str:
-        """
-        Treat missing size values from dxfeed as zero.
-        """
-        if v is None or v == _NaN:
-            return _ZERO
-        return v
+    ask_size: Decimal = _ZERO
 
     @property
     def mid_price(self) -> Decimal:


### PR DESCRIPTION
## Description
Moved default handling in `Quote` for `bid_size` and `ask_size` from the attribute to a custom a before validator, which treats `None` and `NaN` as zero (`Decimal(0)`). Due to this, `Quote` now only supports initialising new objects with all attributes, that is `bid_size` and `ask_size` have to be explicitly specified. However, this is only an issue if for some reason quotes are initialised manually and not streamed from dxfeed.
Added a new test, `test_missing_size_data`, to simulate a `Quote` with missing `bid_size` and `ask_size`.


## Related issue(s)
Fixes #322 

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set)
- [x] New tests added (if applicable)
- [ ] Docs updated (if applicable)