### PR TITLE
fix: allow None for Quote bid_size/ask_size (index NaN)

### DIFF
--- a/tastytrade/dxfeed/quote.py
+++ b/tastytrade/dxfeed/quote.py
@@ -1,9 +1,8 @@
 from decimal import Decimal
+from typing import Optional
 
 from .. import logger
 from .event import Event
-
-_ZERO = Decimal(0)
 
 
 class Quote(Event):
@@ -29,11 +28,13 @@ class Quote(Event):
     #: ask price
     ask_price: Decimal
     #: bid size as integer number (rounded toward zero)
-    #: or decimal for cryptocurrencies
-    bid_size: Decimal = _ZERO
+    #: or decimal for cryptocurrencies.
+    #: None for index symbols where DXLink sends NaN (indices have no order book).
+    bid_size: Optional[Decimal] = None
     #: ask size as integer number (rounded toward zero)
-    #: or decimal for cryptocurrencies
-    ask_size: Decimal = _ZERO
+    #: or decimal for cryptocurrencies.
+    #: None for index symbols where DXLink sends NaN (indices have no order book).
+    ask_size: Optional[Decimal] = None
 
     @property
     def mid_price(self) -> Decimal:
@@ -47,6 +48,9 @@ class Quote(Event):
         """
         Average of bid and ask price weighted by their sizes
         """
+        if self.bid_size is None or self.ask_size is None:
+            logger.warning("Can't compute micro price without sizing!")
+            return self.mid_price
         total_size = self.bid_size + self.ask_size
         if not total_size:  # check for zero, fallback to mid
             logger.warning("Can't compute micro price without sizing!")

--- a/tests/test_dxfeed.py
+++ b/tests/test_dxfeed.py
@@ -37,3 +37,16 @@ def test_wrong_number_data_fields():
 def test_bad_extra_data():
     extra_data = ["SPY", 0, "bad", 0, 0, "Q", 0, "Q", 576.88, 576.9, 230.0, 300.0]
     _ = Quote.from_stream(quote_data + extra_data)
+
+
+def test_index_quote_nan_sizes():
+    """Index symbols (SPX, VIX) return NaN for bid/ask sizes since they have no order book."""
+    index_data = ["SPX", 0, 0, 0, 0, "\x00", 0, "\x00", 4122.49, 4123.65, "NaN", "NaN"]
+    quotes = Quote.from_stream(index_data)
+    assert len(quotes) == 1
+    quote = quotes[0]
+    assert quote.event_symbol == "SPX"
+    assert quote.bid_price is not None
+    assert quote.ask_price is not None
+    assert quote.bid_size is None
+    assert quote.ask_size is None


### PR DESCRIPTION
## Summary

- Make `Quote.bid_size` and `Quote.ask_size` `Optional[Decimal]` (default `None`) so index symbols aren't silently dropped
- Guard `micro_price` property against `None` sizes
- Add test for index quote parsing with NaN sizes

## Problem

Index symbols (SPX, VIX, NDX) return `NaN` for `bid_size` and `ask_size` from DXLink because indices don't have order books. The `change_nan_to_none` validator correctly converts `"NaN"` → `None`, but the `Decimal` typed fields reject `None`, causing a `ValidationError`. Since `from_stream()` silently catches all `ValidationError`s, the entire Quote event is **dropped without any warning**.

```python
# Current behavior — event silently lost
raw = ['SPX', 0, 0, 0, 0, '\x00', 0, '\x00', 4122.49, 4123.65, 'NaN', 'NaN']
result = Quote.from_stream(raw)
len(result)  # → 0 (event dropped!)
```

## Fix

Change `bid_size` and `ask_size` from `Decimal` to `Optional[Decimal]` with a default of `None`. This lets `NaN` values pass through as `None` rather than causing validation failures.

```python
# After fix
result = Quote.from_stream(raw)
len(result)  # → 1
result[0].bid_size  # → None
result[0].ask_size  # → None
result[0].bid_price  # → Decimal('4122.49') ✓
```

## Test plan

- [x] Existing `test_dxfeed.py` tests pass (NaN/Infinity parsing, wrong data fields, bad extra data)
- [x] New `test_index_quote_nan_sizes` verifies SPX quotes with NaN sizes parse correctly
- [x] `micro_price` falls back to `mid_price` when sizes are `None`

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)