### PR TITLE
Handle WebSocket disconnects cleanly in streamer _reader

### DIFF
--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -16,5 +16,12 @@ logger.setLevel(logging.DEBUG)
 from .account import Account
 from .session import Session
 from .streamer import AlertStreamer, DXLinkStreamer
+from .utils import StreamerDisconnect
 
-__all__ = ["Account", "AlertStreamer", "DXLinkStreamer", "Session"]
+__all__ = [
+    "Account",
+    "AlertStreamer",
+    "DXLinkStreamer",
+    "Session",
+    "StreamerDisconnect",
+]

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -37,7 +37,12 @@ from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from anyio.streams.stapled import StapledObjectStream
 from httpx import AsyncClient
-from httpx_ws import AsyncWebSocketSession, WebSocketDisconnect, aconnect_ws
+from httpx_ws import (
+    AsyncWebSocketSession,
+    WebSocketDisconnect,
+    WebSocketNetworkError,
+    aconnect_ws,
+)
 from pydantic import model_validator
 
 from tastytrade import logger, version_str
@@ -57,6 +62,7 @@ from tastytrade.dxfeed import (
 from tastytrade.order import InstrumentType, PlacedComplexOrder, PlacedOrder
 from tastytrade.session import Session
 from tastytrade.utils import (
+    StreamerDisconnect,
     TastytradeData,
     TastytradeError,
     intuitive_iterable,
@@ -247,12 +253,17 @@ class AlertStreamer(AsyncContextManagerMixin):
                 tg.cancel_scope.cancel()
 
     async def _reader(self) -> None:
-        while True:
-            data = await self._websocket.receive_json()
-            logger.debug("received message: %s", data)
-            type_str = data.get("type")
-            if type_str is not None:
-                await self._map_message(type_str, data["data"])
+        try:
+            while True:
+                data = await self._websocket.receive_json()
+                logger.debug("received message: %s", data)
+                type_str = data.get("type")
+                if type_str is not None:
+                    await self._map_message(type_str, data["data"])
+        except WebSocketDisconnect as e:
+            raise StreamerDisconnect(code=e.code, reason=e.reason) from None
+        except WebSocketNetworkError:
+            raise StreamerDisconnect(reason="network error") from None
 
     async def listen(self, alert_class: type[T]) -> AsyncIterator[T]:
         """
@@ -411,6 +422,8 @@ class DXLinkStreamer(AsyncContextManagerMixin):
                         # fix until httpx-ws issue #107 is resolved
                         with CancelScope(shield=True):
                             await self._websocket.close()
+            except* StreamerDisconnect as eg:
+                raise eg.exceptions[0] from None
             except* WebSocketDisconnect as eg:
                 if eg.subgroup(lambda e: getattr(e, "code", None) == 1009):
                     raise TastytradeError(
@@ -441,33 +454,40 @@ class DXLinkStreamer(AsyncContextManagerMixin):
             type: str
 
         await self._setup_connection()
-        while True:
-            message: DXLinkMessage = await self._websocket.receive_json()
-            logger.debug("received: %s", message)
-            if message["type"] == "FEED_DATA":
-                self._map_message(message["data"])
-            elif message["type"] == "SETUP":
-                await self._authenticate_connection()
-            elif message["type"] == "AUTH_STATE":
-                if message["state"] == "AUTHORIZED":
-                    logger.debug("Websocket connection established.")
-                    task_status.started()
-            elif message["type"] == "CHANNEL_OPENED":
-                key = self._channels_reversed[message["channel"]]
-                self._subscription_state[key].set()
-                logger.debug("Channel opened: %s", message)
-            elif message["type"] == "CHANNEL_CLOSED":
-                key = self._channels_reversed[message["channel"]]
-                del self._subscription_state[key]
-                logger.debug("Channel closed: %s", message)
-            elif message["type"] == "FEED_CONFIG":
-                logger.debug("Feed configured: %s", message)
-            elif message["type"] == "KEEPALIVE":
-                pass
-            elif message["type"] == "ERROR":
-                raise TastytradeError(f"Fatal streamer error: {message['message']}")
-            else:
-                logger.error(f"Unknown message: {message}")
+        try:
+            while True:
+                message: DXLinkMessage = await self._websocket.receive_json()
+                logger.debug("received: %s", message)
+                if message["type"] == "FEED_DATA":
+                    self._map_message(message["data"])
+                elif message["type"] == "SETUP":
+                    await self._authenticate_connection()
+                elif message["type"] == "AUTH_STATE":
+                    if message["state"] == "AUTHORIZED":
+                        logger.debug("Websocket connection established.")
+                        task_status.started()
+                elif message["type"] == "CHANNEL_OPENED":
+                    key = self._channels_reversed[message["channel"]]
+                    self._subscription_state[key].set()
+                    logger.debug("Channel opened: %s", message)
+                elif message["type"] == "CHANNEL_CLOSED":
+                    key = self._channels_reversed[message["channel"]]
+                    del self._subscription_state[key]
+                    logger.debug("Channel closed: %s", message)
+                elif message["type"] == "FEED_CONFIG":
+                    logger.debug("Feed configured: %s", message)
+                elif message["type"] == "KEEPALIVE":
+                    pass
+                elif message["type"] == "ERROR":
+                    raise TastytradeError(
+                        f"Fatal streamer error: {message['message']}"
+                    )
+                else:
+                    logger.error(f"Unknown message: {message}")
+        except WebSocketDisconnect as e:
+            raise StreamerDisconnect(code=e.code, reason=e.reason) from None
+        except WebSocketNetworkError:
+            raise StreamerDisconnect(reason="network error") from None
 
     async def _setup_connection(self) -> None:
         message = {

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -226,6 +226,19 @@ class TastytradeError(Exception):
     pass
 
 
+class StreamerDisconnect(Exception):
+    """
+    Raised when the DXLink or Alert WebSocket disconnects unexpectedly.
+    Attributes carry the close code and reason so callers can distinguish
+    server-requested reconnects (code 1012) from network failures.
+    """
+
+    def __init__(self, code=None, reason=''):
+        self.code = code
+        self.reason = reason
+        super().__init__(f"code={code}, reason={reason}")
+
+
 def _dasherize(s: str) -> str:
     """
     Converts a string from snake case to dasherized.


### PR DESCRIPTION
## Summary

- Adds `StreamerDisconnect` exception (with `code` and `reason` attributes) to `tastytrade.utils`
- Catches `WebSocketDisconnect` and `WebSocketNetworkError` in both `DXLinkStreamer._reader` and `AlertStreamer._reader`, re-raising as `StreamerDisconnect`
- Unwraps `StreamerDisconnect` from the `ExceptionGroup` in `DXLinkStreamer.__asynccontextmanager__` so callers receive a plain exception
- Exports `StreamerDisconnect` from the package `__init__.py`

## Motivation

When the DXFeed WebSocket drops — whether from a network error or a server-requested reconnect (close code 1012, `SERVICE_RESTART`) — the raw `httpx_ws` exceptions (`WebSocketNetworkError`, `WebSocketDisconnect`) propagate uncaught from `_reader`. This crashes the anyio `TaskGroup` and surfaces as an `ExceptionGroup` with a full traceback:

```
ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | httpx_ws._exceptions.WebSocketDisconnect: (<CloseReason.SERVICE_RESTART: 1012>, 'Reconnection is required')
    +------------------------------------
```

This makes it difficult for callers to:
1. Distinguish routine disconnects from actual errors
2. Implement appropriate retry strategies (e.g. immediate reconnect for code 1012 vs longer backoff for network failures)
3. Log cleanly without noisy tracebacks for expected events

## Usage

After this change, callers can catch `StreamerDisconnect` and inspect `e.code`:

```python
from tastytrade import DXLinkStreamer, StreamerDisconnect

while True:
    try:
        async with DXLinkStreamer(session) as streamer:
            # ... subscribe and listen ...
    except StreamerDisconnect as e:
        if e.code == 1012:
            await asyncio.sleep(5)   # server-requested, reconnect quickly
        else:
            await asyncio.sleep(30)  # network error, back off
```

## Test plan

- [ ] Verify existing streamer tests still pass
- [ ] Verify `StreamerDisconnect` is raised (not `ExceptionGroup`) on WebSocket close
- [ ] Verify `e.code` is populated correctly for `WebSocketDisconnect` (e.g. 1012)
- [ ] Verify `e.code` is `None` and `e.reason` is `"network error"` for `WebSocketNetworkError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)