### PR TITLE
Make TimeAndSale.exchange_sale_conditions optional (#344)

### DIFF
--- a/tastytrade/dxfeed/timeandsale.py
+++ b/tastytrade/dxfeed/timeandsale.py
@@ -31,8 +31,6 @@ class TimeAndSale(IndexedEvent):
     bid_price: Decimal
     #: the ask price on the market when this time and sale event occured
     ask_price: Decimal
-    #: sale conditions provided for this event by data feed
-    exchange_sale_conditions: str
     #: transaction is concluded by exempting from compliance with some rule
     trade_through_exempt: str
     #: initiator of the trade
@@ -49,3 +47,5 @@ class TimeAndSale(IndexedEvent):
     buyer: None
     #: Undocumented; always None
     seller: None
+    #: sale conditions provided for this event by data feed
+    exchange_sale_conditions: str | None = None


### PR DESCRIPTION
## Description
The field `TimeAndSale.exchange_sale_conditions` is not always present and should therefore be optional.

## Related issue(s)
Fixes #344

## Pre-merge checklist
- [ ] Code formatted correctly (check with `make lint`)
- [ ] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
