### PR TITLE
Switch from httpx to httpx2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,7 @@ authors = [
 ]
 dependencies = [
     "anyio>=4.12.1",
-    "httpx>=0.28.1",
-    "httpx-ws>=0.9.0",
+    "httpx2[ws]>=2.7.0",
     "pandas-market-calendars>=5.1.1",
     "pydantic>=2.12.0",
 ]

--- a/tastytrade/__init__.py
+++ b/tastytrade/__init__.py
@@ -4,7 +4,7 @@ API_URL = "https://api.tastyworks.com"
 API_VERSION = "20251101"
 CERT_URL = "https://api.cert.tastyworks.com"
 PAPER_URL = "https://tastyware.dev/api"
-VERSION = "13.0.2"
+VERSION = "13.1.0"
 
 __version__ = VERSION
 version_str: str = f"tastyware/tastytrade:v{VERSION}"

--- a/tastytrade/paper.py
+++ b/tastytrade/paper.py
@@ -5,8 +5,8 @@ from decimal import Decimal
 from typing import Any, Literal
 from uuid import uuid4
 
-from httpx import AsyncClient
-from httpx_ws import HTTPXWSException
+from httpx2 import AsyncClient
+from httpx2.websockets import HTTPXWSException
 
 from tastytrade import PAPER_URL
 from tastytrade.account import Account

--- a/tastytrade/session.py
+++ b/tastytrade/session.py
@@ -9,14 +9,10 @@ from datetime import date, datetime
 from typing import Any, Self, TypeVar
 
 from anyio import AsyncContextManagerMixin, Lock
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from tastytrade import API_URL, API_VERSION, CERT_URL, logger
-from tastytrade.utils import (
-    TastytradeData,
-    validate_and_parse,
-    validate_response,
-)
+from tastytrade.utils import TastytradeData, validate_and_parse, validate_response
 
 T = TypeVar("T", bound=TastytradeData)
 

--- a/tastytrade/streamer.py
+++ b/tastytrade/streamer.py
@@ -22,8 +22,8 @@ from anyio import Event as AnyioEvent
 from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from anyio.streams.stapled import StapledObjectStream
-from httpx import AsyncClient
-from httpx_ws import AsyncWebSocketSession, WebSocketDisconnect, aconnect_ws
+from httpx2 import AsyncClient
+from httpx2.websockets import AsyncWebSocketSession, WebSocketDisconnect
 from pydantic import ValidationError, model_validator
 
 from tastytrade import logger, version_str
@@ -219,7 +219,7 @@ class AlertStreamer(AsyncContextManagerMixin):
     @asynccontextmanager
     async def __asynccontextmanager__(self) -> AsyncGenerator[Self]:
         async with AsyncClient(**self.session.client_kwargs) as client:
-            async with aconnect_ws(self.base_url, client=client) as self._websocket:
+            async with client.websocket(self.base_url) as self._websocket:
                 logger.debug("Websocket connection established.")
                 async with create_task_group() as tg:
                     tg.start_soon(self._reader)
@@ -366,8 +366,8 @@ class DXLinkStreamer(AsyncContextManagerMixin):
         async with AsyncClient(**self.session.client_kwargs) as client:
             try:
                 # default keepalive doesn't work since TT expects a specific format
-                async with aconnect_ws(
-                    self._wss_url, client=client, keepalive_ping_interval_seconds=None
+                async with client.websocket(
+                    self._wss_url, keepalive_ping_interval_seconds=None
                 ) as self._websocket:
                     logger.debug("Websocket connection established.")
                     async with create_task_group() as tg:

--- a/tastytrade/utils.py
+++ b/tastytrade/utils.py
@@ -6,7 +6,7 @@ from json import JSONDecodeError
 from typing import Any, cast
 from zoneinfo import ZoneInfo
 
-from httpx import Response
+from httpx2 import Response
 from pandas import Timestamp
 from pandas_market_calendars import get_calendar  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict

--- a/uv.lock
+++ b/uv.lock
@@ -303,55 +303,46 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
 ]
 
-[[package]]
-name = "httpx-ws"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpcore" },
-    { name = "httpx" },
+[package.optional-dependencies]
+ws = [
     { name = "wsproto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1154,8 +1145,7 @@ name = "tastytrade"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-ws" },
+    { name = "httpx2", extra = ["ws"] },
     { name = "pandas-market-calendars" },
     { name = "pydantic" },
 ]
@@ -1177,8 +1167,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.12.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "httpx-ws", specifier = ">=0.9.0" },
+    { name = "httpx2", extras = ["ws"], specifier = ">=2.7.0" },
     { name = "pandas-market-calendars", specifier = ">=5.1.1" },
     { name = "pydantic", specifier = ">=2.12.0" },
 ]
@@ -1260,6 +1249,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/ce/0041ddd9160aac0031bcf5ab786c7640d795c797e67c438e15cfedf815c8/trio-0.32.0.tar.gz", hash = "sha256:150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b", size = 605323, upload-time = "2025-10-31T07:18:17.466Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/bf/945d527ff706233636c73880b22c7c953f3faeb9d6c7e2e85bfbfd0134a0/trio-0.32.0-py3-none-any.whl", hash = "sha256:4ab65984ef8370b79a76659ec87aa3a30c5c7c83ff250b4de88c29a8ab6123c5", size = 512030, upload-time = "2025-10-31T07:18:15.885Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Switches async web client from `httpx` to `httpx2` as httpx is no longer maintained. Additionally, since `httpx2` now includes websockets support, the `httpx-ws` dependency is no longer necessary.

## Pre-merge checklist
- [x] Code formatted correctly (check with `make lint`)
- [x] Passing tests locally (check with `make test`, make sure you have `TT_REFRESH`, `TT_SECRET`, and `TT_ACCOUNT` environment variables set)
- [ ] New tests added (if applicable)
- [ ] Docs updated (if applicable)
